### PR TITLE
Change laion metric to L2

### DIFF
--- a/vectordb_bench/backend/dataset.py
+++ b/vectordb_bench/backend/dataset.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 class LAION:
     name: str = "LAION"
     dim: int = 768
-    metric_type: MetricType = MetricType.COSINE
+    metric_type: MetricType = MetricType.L2
     use_shuffled: bool = False
 
     @property


### PR DESCRIPTION
The groudthruth is caculated with L2, change to L2 will skip normalization for DBs don't support COSIN metric.