### PR TITLE
Remove 100K Performance cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ ruff check vectordb_bench --fix
 ![image](https://github.com/zilliztech/VectorDBBench/assets/105927039/66ab83c4-656e-41a8-a643-d9790faccbeb)
 This is the main page of VectorDBBench, which displays the standard benchmark results we provide. Additionally, results of all tests performed by users themselves will also be shown here. We also offer the ability to select and compare results from multiple tests simultaneously.
 
-The standard benchmark results displayed here include all 12 cases that we currently support for all our clients (Milvus, Zilliz Cloud, Elastic Search, Qdrant Cloud, and Weaviate Cloud). However, as some systems may not be able to complete all the tests successfully due to issues like Out of Memory (OOM) or timeouts, not all clients are included in every case.
+The standard benchmark results displayed here include all 9 cases that we currently support for all our clients (Milvus, Zilliz Cloud, Elastic Search, Qdrant Cloud, and Weaviate Cloud). However, as some systems may not be able to complete all the tests successfully due to issues like Out of Memory (OOM) or timeouts, not all clients are included in every case.
 ### Run Test Page
 ![image](https://github.com/zilliztech/VectorDBBench/assets/105927039/a789099a-3707-4214-8052-b73463b8f2c6)
 This is the page to run a test:
@@ -73,7 +73,7 @@ Now we can only run one task at the same time.
 ### Client
 Our client module is designed with flexibility and extensibility in mind, aiming to integrate APIs from different systems seamlessly. As of now, it supports Milvus, Zilliz Cloud, Elastic Search, Pinecone, Qdrant, and Weaviate. Stay tuned for more options, as we are consistently working on extending our reach to other systems.
 ### Benchmark Cases
-We've developed an array of 12 comprehensive benchmark cases to test vector databases' various capabilities, each designed to give you a different piece of the puzzle. These cases are categorized into three main types:
+We've developed an array of 9 comprehensive benchmark cases to test vector databases' various capabilities, each designed to give you a different piece of the puzzle. These cases are categorized into three main types:
 #### Capacity Case
 - **Large Dim:** Tests the database's loading capacity by inserting large-dimension vectors (GIST 100K vectors, 960 dimensions) until fully loaded. The final number of inserted vectors is reported.
 - **Small Dim:** Similar to the Large Dim case but uses small-dimension vectors (SIFT 100K vectors, 128 dimensions).
@@ -81,14 +81,11 @@ We've developed an array of 12 comprehensive benchmark cases to test vector data
 - **XLarge Dataset:** Measures search performance with a massive dataset (LAION 100M vectors, 768 dimensions) at varying parallel levels. The results include index building time, recall, latency, and maximum QPS.
 - **Large Dataset:** Similar to the XLarge Dataset case, but uses a slightly smaller dataset (Cohere 10M vectors, 768 dimensions).
 - **Medium Dataset:** A case using a medium dataset (Cohere 1M vectors, 768 dimensions).
-- **Small Dataset:** This case uses a small dataset (Cohere 100K vectors, 768 dimensions).
 #### Filtering Search Performance Case
 - **Large Dataset, Low Filtering Rate:** Evaluates search performance with a large dataset (Cohere 10M vectors, 768 dimensions) under a low filtering rate (1% vectors) at different parallel levels.
 - **Medium Dataset, Low Filtering Rate:** This case uses a medium dataset (Cohere 1M vectors, 768 dimensions) with a similar low filtering rate.
-- **Small Dataset, Low Filtering Rate:** This case uses a small dataset (Cohere 100K vectors, 768 dimensions) with a low filtering rate.
 - **Large Dataset, High Filtering Rate:** It tests with a large dataset (Cohere 10M vectors, 768 dimensions) but under a high filtering rate (99% vectors).
 - **Medium Dataset, High Filtering Rate:** This case uses a medium dataset (Cohere 1M vectors, 768 dimensions) with a high filtering rate.
-- **Small Dataset, High Filtering Rate:** Finally, this case uses a small dataset (Cohere 100K vectors, 768 dimensions) under a high filtering rate.
 For a quick reference, here is a table summarizing the key aspects of each case:
 
 Case No. | Case Type | Dataset Size | Dataset Type | Filtering Rate | Results |
@@ -98,13 +95,10 @@ Case No. | Case Type | Dataset Size | Dataset Type | Filtering Rate | Results |
 3 | Search Performance Case | XLarge Dataset | LAION 100M vectors, 768 dimensions | N/A | Index building time, recall, latency, maximum QPS |
 4 | Search Performance Case | Large Dataset | Cohere 10M vectors, 768 dimensions | N/A | Index building time, recall, latency, maximum QPS |
 5 | Search Performance Case | Medium Dataset | Cohere 1M vectors, 768 dimensions | N/A | Index building time, recall, latency, maximum QPS |
-6 | Search Performance Case | Small Dataset | Cohere 100K vectors, 768 dimensions | N/A | Index building time, recall, latency, maximum QPS |
-7 | Filtering Search Performance Case | Large Dataset, Low Filtering Rate | Cohere 10M vectors, 768 dimensions | 1% vectors | Index building time, recall, latency, maximum QPS |
-8 | Filtering Search Performance Case | Medium Dataset, Low Filtering Rate | Cohere 1M vectors, 768 dimensions | 1% vectors | Index building time, recall, latency, maximum QPS |
-9 | Filtering Search Performance Case | Small Dataset, Low Filtering Rate | Cohere 100K vectors, 768 dimensions | 1% vectors | Index building time, recall, latency, maximum QPS |
-10 | Filtering Search Performance Case | Large Dataset, High Filtering Rate | Cohere 10M vectors, 768 dimensions | 99% vectors | Index building time, recall, latency, maximum QPS |
-11 | Filtering Search Performance Case | Medium Dataset, High Filtering Rate | Cohere 1M vectors, 768 dimensions | 99% vectors | Index building time, recall, latency, maximum QPS |
-12 | Filtering Search Performance Case | Small Dataset, High Filtering Rate | Cohere 100K vectors, 768 dimensions | 99% vectors | Index building time, recall, latency, maximum QPS |
+6 | Filtering Search Performance Case | Large Dataset, Low Filtering Rate | Cohere 10M vectors, 768 dimensions | 1% vectors | Index building time, recall, latency, maximum QPS |
+7 | Filtering Search Performance Case | Medium Dataset, Low Filtering Rate | Cohere 1M vectors, 768 dimensions | 1% vectors | Index building time, recall, latency, maximum QPS |
+8 | Filtering Search Performance Case | Large Dataset, High Filtering Rate | Cohere 10M vectors, 768 dimensions | 99% vectors | Index building time, recall, latency, maximum QPS |
+9 | Filtering Search Performance Case | Medium Dataset, High Filtering Rate | Cohere 1M vectors, 768 dimensions | 99% vectors | Index building time, recall, latency, maximum QPS |
 
 Each case provides an in-depth examination of a vector database's abilities, providing you a comprehensive view of the database's performance.
 
@@ -125,7 +119,7 @@ VectorDBBench aims to provide a more comprehensive, multi-faceted testing enviro
 
 1. Navigate to the vectordb_bench/backend/clients directory.
 2. Create a new folder for your client, for example, "new_client".
-3. Inside the "new_client" folder, create two files: new_client.py and config.py. 
+3. Inside the "new_client" folder, create two files: new_client.py and config.py.
 
 **Step 2: Implement new_client.py and config.py**
 

--- a/tests/ut_cases.py
+++ b/tests/ut_cases.py
@@ -1,0 +1,46 @@
+from vectordb_bench.backend.cases import (
+    PerformanceCase,
+    CaseType,
+)
+
+import vectordb_bench.backend.dataset as ds
+from pydantic.dataclasses import dataclass
+
+@dataclass
+class Cohere_S(ds.Cohere):
+    label: str = "SMALL"
+    size: int  = 100_000
+
+@dataclass
+class Glove_S(ds.Glove):
+    label: str = "SMALL"
+    size : int = 100_000
+
+
+class Performance100K99p(PerformanceCase):
+    case_id: CaseType = CaseType.PerformanceSHigh
+    filter_rate: float | int | None = 0.99
+    dataset: ds.DataSet = ds.get(ds.Name.Cohere, ds.Label.SMALL)
+    name: str = "Filtering Search Performance Test (100K Dataset, 768 Dim, Filter 99%)"
+    description: str = """This case tests the search performance of a vector database with a small dataset (<b>Cohere 100K vectors</b>, 768 dimensions) under a high filtering rate (<b>99% vectors</b>), at varying parallel levels.
+Results will show index building time, recall, and maximum QPS."""
+
+class Performance100K1p(PerformanceCase):
+    case_id: CaseType = CaseType.PerformanceSLow
+    filter_rate: float | int | None = 0.01
+    dataset: ds.DataSet = ds.get(ds.Name.Cohere, ds.Label.SMALL)
+    name: str = "Filtering Search Performance Test (100K Dataset, 768 Dim, Filter 1%)"
+    description: str = (
+        """This case tests the search performance of a vector database with a small dataset (<b>Cohere 100K vectors</b>, 768 dimensions) under a low filtering rate (<b>1% vectors</b>), at varying parallel levels.
+Results will show index building time, recall, and maximum QPS.""",
+    )
+
+
+class Performance100K(PerformanceCase):
+    case_id: CaseType = CaseType.PerformanceSZero
+    dataset: ds.DataSet = ds.get(ds.Name.Cohere, ds.Label.SMALL)
+    name: str = "Search Performance Test (100K Dataset, 768 Dim)"
+    description: str = """This case tests the search performance of a vector database with a small dataset (<b>Cohere 100K vectors</b>, 768 dimensions) at varying parallel levels.
+Results will show index building time, recall, and maximum QPS."""
+
+

--- a/vectordb_bench/backend/cases.py
+++ b/vectordb_bench/backend/cases.py
@@ -30,7 +30,6 @@ class CaseType(Enum):
     Performance100M = "Search Performance Test (100M Dataset, 768 Dim)"
     PerformanceLZero = "Search Performance Test (10M Dataset, 768 Dim)"
     PerformanceMZero = "Search Performance Test (1M Dataset, 768 Dim)"
-    PerformanceSZero = "Search Performance Test (100K Dataset, 768 Dim)"
 
     PerformanceLLow = (
         "Filtering Search Performance Test (10M Dataset, 768 Dim, Filter 1%)"
@@ -38,17 +37,11 @@ class CaseType(Enum):
     PerformanceMLow = (
         "Filtering Search Performance Test (1M Dataset, 768 Dim, Filter 1%)"
     )
-    PerformanceSLow = (
-        "Filtering Search Performance Test (100K Dataset, 768 Dim, Filter 1%)"
-    )
     PerformanceLHigh = (
         "Filtering Search Performance Test (10M Dataset, 768 Dim, Filter 99%)"
     )
     PerformanceMHigh = (
         "Filtering Search Performance Test (1M Dataset, 768 Dim, Filter 99%)"
-    )
-    PerformanceSHigh = (
-        "Filtering Search Performance Test (100K Dataset, 768 Dim, Filter 99%)"
     )
 
     def get(self) -> Case:
@@ -105,7 +98,7 @@ class CapacityLDimCase(CapacityCase):
     case_id: CaseType = CaseType.CapacityLDim
     dataset: ds.DataSet = ds.get(ds.Name.GIST, ds.Label.SMALL)
     name: str = "Capacity Test (960 Dim Repeated)"
-    description: str = """This case tests the vector database's loading capacity by repeatedly inserting large-dimension vectors (GIST 100K vectors, <b>960 dimensions</b>) until it is fully loaded.  
+    description: str = """This case tests the vector database's loading capacity by repeatedly inserting large-dimension vectors (GIST 100K vectors, <b>960 dimensions</b>) until it is fully loaded.
 Number of inserted vectors will be reported."""
 
 
@@ -113,7 +106,7 @@ class CapacitySDimCase(CapacityCase):
     case_id: CaseType = CaseType.CapacitySDim
     dataset: ds.DataSet = ds.get(ds.Name.SIFT, ds.Label.SMALL)
     name: str = "Capacity Test (128 Dim Repeated)"
-    description: str = """This case tests the vector database's loading capacity by repeatedly inserting small-dimension vectors (SIFT 100K vectors, <b>128 dimensions</b>) until it is fully loaded.  
+    description: str = """This case tests the vector database's loading capacity by repeatedly inserting small-dimension vectors (SIFT 100K vectors, <b>128 dimensions</b>) until it is fully loaded.
 Number of inserted vectors will be reported."""
 
 
@@ -130,14 +123,6 @@ class PerformanceMZero(PerformanceCase):
     dataset: ds.DataSet = ds.get(ds.Name.Cohere, ds.Label.MEDIUM)
     name: str = "Search Performance Test (1M Dataset, 768 Dim)"
     description: str = """This case tests the search performance of a vector database with a medium dataset (<b>Cohere 1M vectors</b>, 768 dimensions) at varying parallel levels.
-Results will show index building time, recall, and maximum QPS."""
-
-
-class PerformanceSZero(PerformanceCase):
-    case_id: CaseType = CaseType.PerformanceSZero
-    dataset: ds.DataSet = ds.get(ds.Name.Cohere, ds.Label.SMALL)
-    name: str = "Search Performance Test (100K Dataset, 768 Dim)"
-    description: str = """This case tests the search performance of a vector database with a small dataset (<b>Cohere 100K vectors</b>, 768 dimensions) at varying parallel levels.
 Results will show index building time, recall, and maximum QPS."""
 
 
@@ -159,17 +144,6 @@ class PerformanceMLow(PerformanceCase):
 Results will show index building time, recall, and maximum QPS."""
 
 
-class PerformanceSLow(PerformanceCase):
-    case_id: CaseType = CaseType.PerformanceSLow
-    filter_rate: float | int | None = 0.01
-    dataset: ds.DataSet = ds.get(ds.Name.Cohere, ds.Label.SMALL)
-    name: str = "Filtering Search Performance Test (100K Dataset, 768 Dim, Filter 1%)"
-    description: str = (
-        """This case tests the search performance of a vector database with a small dataset (<b>Cohere 100K vectors</b>, 768 dimensions) under a low filtering rate (<b>1% vectors</b>), at varying parallel levels.
-Results will show index building time, recall, and maximum QPS.""",
-    )
-
-
 class PerformanceLHigh(PerformanceCase):
     case_id: CaseType = CaseType.PerformanceLHigh
     filter_rate: float | int | None = 0.99
@@ -188,14 +162,6 @@ class PerformanceMHigh(PerformanceCase):
 Results will show index building time, recall, and maximum QPS."""
 
 
-class PerformanceSHigh(PerformanceCase):
-    case_id: CaseType = CaseType.PerformanceSHigh
-    filter_rate: float | int | None = 0.99
-    dataset: ds.DataSet = ds.get(ds.Name.Cohere, ds.Label.SMALL)
-    name: str = "Filtering Search Performance Test (100K Dataset, 768 Dim, Filter 99%)"
-    description: str = """This case tests the search performance of a vector database with a small dataset (<b>Cohere 100K vectors</b>, 768 dimensions) under a high filtering rate (<b>99% vectors</b>), at varying parallel levels.
-Results will show index building time, recall, and maximum QPS."""
-
 
 class Performance100M(PerformanceCase):
     case_id: CaseType = CaseType.Performance100M
@@ -213,12 +179,9 @@ type2case = {
     CaseType.Performance100M: Performance100M,
     CaseType.PerformanceLZero: PerformanceLZero,
     CaseType.PerformanceMZero: PerformanceMZero,
-    CaseType.PerformanceSZero: PerformanceSZero,
 
     CaseType.PerformanceLLow: PerformanceLLow,
     CaseType.PerformanceMLow: PerformanceMLow,
-    CaseType.PerformanceSLow: PerformanceSLow,
     CaseType.PerformanceLHigh: PerformanceLHigh,
     CaseType.PerformanceMHigh: PerformanceMHigh,
-    CaseType.PerformanceSHigh: PerformanceSHigh,
 }

--- a/vectordb_bench/backend/dataset.py
+++ b/vectordb_bench/backend/dataset.py
@@ -97,11 +97,6 @@ class GIST_M(GIST):
     size: int  = 1_000_000
 
 @dataclass
-class Cohere_S(Cohere):
-    label: str = "SMALL"
-    size: int  = 100_000
-
-@dataclass
 class Cohere_M(Cohere):
     label: str = "MEDIUM"
     size: int = 1_000_000
@@ -110,11 +105,6 @@ class Cohere_M(Cohere):
 class Cohere_L(Cohere):
     label : str = "LARGE"
     size  : int = 10_000_000
-
-@dataclass
-class Glove_S(Glove):
-    label: str = "SMALL"
-    size : int = 100_000
 
 @dataclass
 class Glove_M(Glove):
@@ -371,12 +361,10 @@ _global_ds_mapping = {
         Label.MEDIUM: DataSet(data=GIST_M()),
     },
     Name.Cohere: {
-        Label.SMALL: DataSet(data=Cohere_S()),
         Label.MEDIUM: DataSet(data=Cohere_M()),
         Label.LARGE: DataSet(data=Cohere_L()),
     },
     Name.Glove:{
-        Label.SMALL: DataSet(data=Glove_S()),
         Label.MEDIUM: DataSet(data=Glove_M()),
     },
     Name.SIFT: {


### PR DESCRIPTION
We use 100K for correctness and convenience of the code, but the results are actually not representative. So we move the 100K performance cases into unittests, and remove all results related to it.