### PR TITLE
Import database client while in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,35 @@
 python >= 3.11
 ```
 ### Install
-``` shell
+**Install vectordb-bench with only PyMilvus**
+```shell
 pip install vectordb-bench
 ```
+
+**Install all database clients**
+
+``` shell
+pip install vectordb-bench[all]
+```
+**Install the specific database client**
+
+```shell
+pip install vectordb-bench[pinecone]
+```
+All the database client supported
+
+|Optional database client|install command|
+|---------------|---------------|
+|pymilvus(*default*)|`pip install vectordb-bench`|
+|all|`pip install vectordb-bench[all]`|
+|qdrant|`pip install vectordb-bench[qdrant]`|
+|pinecone|`pip install vectordb-bench[pinecone]`|
+|weaviate|`pip install vectordb-bench[weaviate]`|
+|elastic|`pip install vectordb-bench[elastic]`|
+|pgvector|`pip install vectordb-bench[pgvector]`|
+|redis|`pip install vectordb-bench[redis]`|
+|chromadb|`pip install vectordb-bench[chromadb]`|
+
 ### Run
 
 ``` shell
@@ -50,6 +76,8 @@ To facilitate the presentation of test results and provide a comprehensive perfo
 ### Install requirements
 ``` shell
 pip install -e '.[test]'
+
+pip install -e '.[pinecone]'
 ```
 ### Run test server
 ```
@@ -185,27 +213,41 @@ In this final step, you will import your DB client into clients/__init__.py and 
 2. Add your NewClient to the DB enum. 
 3. Update the db2client dictionary by adding an entry for your NewClient.
 Example implementation in clients/__init__.py:
+
 ```python
 #clients/__init__.py
 
-from .new_client.new_client import NewClient
-
-#Add NewClient to the DB enum
+# Add NewClient to the DB enum
 class DB(Enum):
     ...
     DB.NewClient = "NewClient"
 
-#Add NewClient to the db2client dictionary
-db2client = {
-    DB.Milvus: Milvus,
-    ...
-    DB.NewClient: NewClient
-}
+    @property
+    def init_cls(self) -> Type[VectorDB]:
+        ...
+        if self == DB.NewClient:
+            from .new_client.new_client import NewClient
+            return NewClient
+        ...
+
+    @property
+    def config_cls(self) -> Type[DBConfig]:
+        ...
+        if self == DB.NewClient:
+            from .new_client.config import NewClientConfig
+            return NewClientConfig
+        ...
+
+    def case_config_cls(self, ...)
+        if self == DB.NewClient:
+            from .new_client.config import NewClientCaseConfig
+            return NewClientCaseConfig
+
 ```
 That's it! You have successfully added a new DB client to the vectordb_bench project.
 
 ## Rules
-### Installation 
+### Installation
 The system under test can be installed in any form to achieve optimal performance. This includes but is not limited to binary deployment, Docker, and cloud services.
 ### Fine-Tuning
 For the system under test, we use the default server-side configuration to maintain the authenticity and representativeness of our results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,24 +24,15 @@ dependencies = [
     "streamlit-autorefresh",
     "streamlit>=1.23.0",
     "streamlit_extras",
-    "grpcio==1.53.0", # for qdrant-client and pymilvus
-    "grpcio-tools==1.53.0", # for qdrant-client and pymilvus
-    "pymilvus", # with pandas, numpy, ujson
-    "qdrant-client",
-    "pinecone-client",
-    "weaviate-client",
-    "elasticsearch",
-    "plotly",
-    "pydantic==v1.10.7", # for qdrant-client
-    "environs",
-    "scikit-learn",
+    "tqdm",
     "s3fs",
     "psutil",
     "polars",
-    "pgvector",
-    "sqlalchemy",
-    "redis",
-    "chromadb",
+    "plotly",
+    "environs",
+    "pydantic<v2",
+    "scikit-learn",
+    "pymilvus", # with pandas, numpy, ujson
 ]
 dynamic = ["version"]
 
@@ -50,6 +41,27 @@ test = [
     "ruff",
     "pytest",
 ]
+
+all = [
+    "grpcio==1.53.0", # for qdrant-client and pymilvus
+    "grpcio-tools==1.53.0", # for qdrant-client and pymilvus
+    "qdrant-client",
+    "pinecone-client",
+    "weaviate-client",
+    "elasticsearch",
+    "pgvector",
+    "sqlalchemy",
+    "redis",
+    "chromadb",
+]
+
+qdrant = [ "qdrant-client" ]
+pinecone = [ "pinecone-client" ]
+weaviate = [ "weaviate-client" ]
+elastic = [ "elasticsearch" ]
+pgvector = [ "pgvector", "sqlalchemy" ]
+redis = [ "redis" ]
+chromadb = [ "chromadb" ]
 
 [project.urls]
 "repository" = "https://github.com/zilliztech/VectorDBBench"

--- a/tests/test_chroma.py
+++ b/tests/test_chroma.py
@@ -33,7 +33,7 @@ class TestChroma:
         assert DB.Chroma.value == "Chroma"
 
         dbcls = DB.Chroma.init_cls
-        dbConfig = dbcls.config_cls()
+        dbConfig = DB.Chroma.config_cls
         
 
         dim = 16

--- a/tests/test_elasticsearch_cloud.py
+++ b/tests/test_elasticsearch_cloud.py
@@ -19,8 +19,8 @@ class TestModels:
         assert DB.ElasticCloud.config == ElasticsearchConfig
 
         dbcls = DB.ElasticCloud.init_cls
-        dbConfig = dbcls.config_cls()(cloud_id=cloud_id, password=password)
-        dbCaseConfig = dbcls.case_config_cls()(
+        dbConfig = DB.ElasticCloud.config_cls(cloud_id=cloud_id, password=password)
+        dbCaseConfig = DB.ElasticCloud.case_config_cls()(
             metric_type=MetricType.L2, efConstruction=64, M=16, num_candidates=100
         )
 

--- a/vectordb_bench/backend/assembler.py
+++ b/vectordb_bench/backend/assembler.py
@@ -41,6 +41,10 @@ class Assembler:
                 db2runner[db] = []
             db2runner[db].append(r)
 
+        # check dbclient installed
+        for k in db2runner.keys():
+            _ = k.init_cls
+
         # sort by dataset size
         for k in db2runner.keys():
             db2runner[k].sort(key=lambda x:x.ca.dataset.data.size)

--- a/vectordb_bench/backend/clients/__init__.py
+++ b/vectordb_bench/backend/clients/__init__.py
@@ -9,15 +9,6 @@ from .api import (
     MetricType,
 )
 
-from .milvus.milvus import Milvus
-from .elastic_cloud.elastic_cloud import ElasticCloud
-from .pinecone.pinecone import Pinecone
-from .weaviate_cloud.weaviate_cloud import WeaviateCloud
-from .qdrant_cloud.qdrant_cloud import QdrantCloud
-from .zilliz_cloud.zilliz_cloud import ZillizCloud
-from .pgvector.pgvector import PgVector
-from .redis.redis import Redis
-from .chroma.chroma import ChromaClient
 
 class DB(Enum):
     """Database types
@@ -44,23 +35,109 @@ class DB(Enum):
 
     @property
     def init_cls(self) -> Type[VectorDB]:
-        return db2client.get(self)
+        """Import while in use"""
+        if self == DB.Milvus:
+            from .milvus.milvus import Milvus
+            return Milvus
 
+        if self == DB.ZillizCloud:
+            from .zilliz_cloud.zilliz_cloud import ZillizCloud
+            return ZillizCloud
 
-db2client = {
-    DB.Milvus: Milvus,
-    DB.ZillizCloud: ZillizCloud,
-    DB.WeaviateCloud: WeaviateCloud,
-    DB.ElasticCloud: ElasticCloud,
-    DB.QdrantCloud: QdrantCloud,
-    DB.Pinecone: Pinecone,
-    DB.PgVector: PgVector,
-    DB.Redis: Redis,
-    DB.Chroma: ChromaClient
-}
+        if self == DB.Pinecone:
+            from .pinecone.pinecone import Pinecone
+            return Pinecone
 
-for db in DB:
-    assert issubclass(db.init_cls, VectorDB)
+        if self == DB.ElasticCloud:
+            from .elastic_cloud.elastic_cloud import ElasticCloud
+            return ElasticCloud
+
+        if self == DB.QdrantCloud:
+            from .qdrant_cloud.qdrant_cloud import QdrantClient
+            return QdrantClient
+
+        if self == DB.WeaviateCloud:
+            from .weaviate_cloud.weaviate_cloud import WeaviateCloud
+            return WeaviateCloud
+
+        if self == DB.PgVector:
+            from .pgvector.pgvector import PgVector
+            return PgVector
+
+        if self == DB.Redis:
+            from .redis.redis import Redis
+            return Redis
+
+        if self == DB.Chroma:
+            from .chroma.chroma import ChromaClient
+            return ChromaClient
+
+    @property
+    def config_cls(self) -> Type[DBConfig]:
+        """Import while in use"""
+        if self == DB.Milvus:
+            from .milvus.config import MilvusConfig
+            return MilvusConfig
+
+        if self == DB.ZillizCloud:
+            from .zilliz_cloud.config import ZillizCloudConfig
+            return ZillizCloudConfig
+
+        if self == DB.Pinecone:
+            from .pinecone.config import PineconeConfig
+            return PineconeConfig
+
+        if self == DB.ElasticCloud:
+            from .elastic_cloud.config import ElasticCloudConfig
+            return ElasticCloudConfig
+
+        if self == DB.QdrantCloud:
+            from .qdrant_cloud.config import QdrantConfig
+            return QdrantConfig
+
+        if self == DB.WeaviateCloud:
+            from .weaviate_cloud.config import WeaviateConfig
+            return WeaviateConfig
+
+        if self == DB.PgVector:
+            from .pgvector.config import PgVectorConfig
+            return PgVectorConfig
+
+        if self == DB.Redis:
+            from .redis.config import RedisConfig
+            return RedisConfig
+
+        if self == DB.Chroma:
+            from .chroma.config import ChromaConfig
+            return ChromaConfig
+
+    def case_config_cls(self, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
+        if self == DB.Milvus:
+            from .milvus.config import _milvus_case_config
+            return _milvus_case_config.get(index_type)
+
+        if self == DB.ZillizCloud:
+            from .zilliz_cloud.config import AutoIndexConfig
+            return AutoIndexConfig
+
+        if self == DB.ElasticCloud:
+            from .elastic_cloud.config import ElasticCloudIndexConfig
+            return ElasticCloudIndexConfig
+
+        if self == DB.QdrantCloud:
+            from .qdrant_cloud.config import QdrantIndexConfig
+            return QdrantIndexConfig
+
+        if self == DB.WeaviateCloud:
+            from .weaviate_cloud.config import WeaviateIndexConfig
+            return WeaviateIndexConfig
+
+        if self == DB.PgVector:
+            from .pgvector.config import PgVectorIndexConfig
+            return PgVectorIndexConfig
+
+        # DB.Pinecone, DB.Chroma, DB.Redis
+        return EmptyDBCaseConfig
 
 
 __all__ = [

--- a/vectordb_bench/backend/clients/api.py
+++ b/vectordb_bench/backend/clients/api.py
@@ -105,18 +105,6 @@ class VectorDB(ABC):
         """
         raise NotImplementedError
 
-    @classmethod
-    @abstractmethod
-    def config_cls(self) -> Type[DBConfig]:
-        raise NotImplementedError
-
-
-    @classmethod
-    @abstractmethod
-    def case_config_cls(self, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        raise NotImplementedError
-
-
     @abstractmethod
     @contextmanager
     def init(self) -> None:
@@ -127,6 +115,10 @@ class VectorDB(ABC):
             >>>     self.insert_embeddings()
         """
         raise NotImplementedError
+
+    def need_normalize_cosine(self) -> bool:
+        """Wheather this database need to normalize dataset to support COSINE"""
+        return False
 
     @abstractmethod
     def insert_embeddings(

--- a/vectordb_bench/backend/clients/chroma/chroma.py
+++ b/vectordb_bench/backend/clients/chroma/chroma.py
@@ -1,11 +1,8 @@
 import chromadb
 import logging 
-import numpy as np
 from contextlib import contextmanager
-from typing import Any, Type
-from ..api import VectorDB, DBConfig, DBCaseConfig, EmptyDBCaseConfig, IndexType
-from .config import ChromaConfig
-from chromadb.config import Settings
+from typing import Any
+from ..api import VectorDB, DBCaseConfig
 
 log = logging.getLogger(__name__)
 class ChromaClient(VectorDB):
@@ -40,13 +37,6 @@ class ChromaClient(VectorDB):
                 drop_old = False
                 log.info(f"Chroma client drop_old collection: {self.collection_name}")
 
-
-    def config_cls() -> Type[DBConfig]:
-        return ChromaConfig
-    
-    def case_config_cls(index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return EmptyDBCaseConfig
-    
     @contextmanager
     def init(self) -> None:
         """ create and destory connections to database.

--- a/vectordb_bench/backend/clients/elastic_cloud/elastic_cloud.py
+++ b/vectordb_bench/backend/clients/elastic_cloud/elastic_cloud.py
@@ -1,9 +1,9 @@
 import logging
 import time
 from contextlib import contextmanager
-from typing import Iterable, Type
-from ..api import VectorDB, DBCaseConfig, DBConfig, IndexType
-from .config import ElasticCloudIndexConfig, ElasticCloudConfig
+from typing import Iterable
+from ..api import VectorDB
+from .config import ElasticCloudIndexConfig
 from elasticsearch.helpers import bulk
 
 
@@ -41,17 +41,6 @@ class ElasticCloud(VectorDB):
             if is_existed_res.raw:
                 client.indices.delete(index=self.indice)
             self._create_indice(client)
-
-
-    @classmethod
-    def config_cls(cls) -> Type[DBConfig]:
-        return ElasticCloudConfig
-
-
-    @classmethod
-    def case_config_cls(cls, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return ElasticCloudIndexConfig
-
 
     @contextmanager
     def init(self) -> None:

--- a/vectordb_bench/backend/clients/milvus/milvus.py
+++ b/vectordb_bench/backend/clients/milvus/milvus.py
@@ -70,15 +70,6 @@ class Milvus(VectorDB):
 
         connections.disconnect("default")
 
-    @classmethod
-    def config_cls(cls) -> Type[DBConfig]:
-        return MilvusConfig
-
-    @classmethod
-    def case_config_cls(cls, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return _milvus_case_config.get(index_type)
-
-
     @contextmanager
     def init(self) -> None:
         """
@@ -156,6 +147,10 @@ class Milvus(VectorDB):
     def optimize(self):
         assert self.col, "Please call self.init() before"
         self._optimize()
+
+    def need_normalize_cosine(self) -> bool:
+        """Wheather this database need to normalize dataset to support COSINE"""
+        return True
 
     def insert_embeddings(
         self,

--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -1,14 +1,11 @@
 """Wrapper around the Pgvector vector database over VectorDB"""
 
 import logging
-import time
 from contextlib import contextmanager
-from typing import Any, Type
-from functools import wraps
+from typing import Any
 
-from ..api import VectorDB, DBConfig, DBCaseConfig, IndexType
+from ..api import VectorDB, DBCaseConfig
 from pgvector.sqlalchemy import Vector
-from .config import PgVectorConfig, PgVectorIndexConfig
 from sqlalchemy import (
     MetaData,
     create_engine,
@@ -66,15 +63,6 @@ class PgVector(VectorDB):
             # self.pg_table.drop(pg_engine, checkfirst=True)
             pq_metadata.drop_all(pg_engine)
             self._create_table(dim, pg_engine)
-
-    
-    @classmethod
-    def config_cls(cls) -> Type[DBConfig]:
-        return PgVectorConfig
-
-    @classmethod
-    def case_config_cls(cls, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return PgVectorIndexConfig
 
     @contextmanager
     def init(self) -> None:

--- a/vectordb_bench/backend/clients/pinecone/config.py
+++ b/vectordb_bench/backend/clients/pinecone/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, SecretStr
+from pydantic import SecretStr
 from ..api import DBConfig
 
 

--- a/vectordb_bench/backend/clients/qdrant_cloud/config.py
+++ b/vectordb_bench/backend/clients/qdrant_cloud/config.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel, SecretStr
 
 from ..api import DBConfig, DBCaseConfig, MetricType
-from qdrant_client.models import Distance
 
 
 class QdrantConfig(DBConfig):
@@ -20,10 +19,12 @@ class QdrantIndexConfig(BaseModel, DBCaseConfig):
 
     def parse_metric(self) -> str:
         if self.metric_type == MetricType.L2:
-            return Distance.EUCLID
-        elif self.metric_type == MetricType.IP:
-            return Distance.DOT
-        return Distance.COSINE
+            return "Euclid"
+
+        if self.metric_type == MetricType.IP:
+            return "Dot"
+
+        return "Cosine"
 
     def index_param(self) -> dict:
         params = {"distance": self.parse_metric()}

--- a/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
+++ b/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
@@ -3,10 +3,8 @@
 import logging
 import time
 from contextlib import contextmanager
-from typing import Type
 
-from ..api import VectorDB, DBConfig, DBCaseConfig, IndexType
-from .config import QdrantConfig, QdrantIndexConfig
+from ..api import VectorDB, DBCaseConfig
 from qdrant_client.http.models import (
     CollectionStatus,
     VectorParams,
@@ -48,14 +46,6 @@ class QdrantCloud(VectorDB):
 
         self._create_collection(dim, tmp_client)
         tmp_client = None
-
-    @classmethod
-    def config_cls(cls) -> Type[DBConfig]:
-        return QdrantConfig
-
-    @classmethod
-    def case_config_cls(cls, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return QdrantIndexConfig
 
     @contextmanager
     def init(self) -> None:

--- a/vectordb_bench/backend/clients/redis/redis.py
+++ b/vectordb_bench/backend/clients/redis/redis.py
@@ -67,13 +67,6 @@ class Redis(VectorDB):
             rs = conn.ft(INDEX_NAME)
             rs.create_index(schema, definition=definition)
 
-
-    def config_cls() -> Type[DBConfig]:
-        return RedisConfig
-    
-    def case_config_cls(index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return EmptyDBCaseConfig
-    
     @contextmanager
     def init(self) -> None:
         """ create and destory connections to database.

--- a/vectordb_bench/backend/clients/weaviate_cloud/config.py
+++ b/vectordb_bench/backend/clients/weaviate_cloud/config.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel, SecretStr
-import weaviate
 
 from ..api import DBConfig, DBCaseConfig, MetricType
 
@@ -11,7 +10,7 @@ class WeaviateConfig(DBConfig):
     def to_dict(self) -> dict:
         return {
             "url": self.url.get_secret_value(),
-            "auth_client_secret": weaviate.AuthApiKey(api_key=self.api_key.get_secret_value()),
+            "auth_client_secret": self.api_key.get_secret_value(),
         }
 
 

--- a/vectordb_bench/backend/clients/weaviate_cloud/weaviate_cloud.py
+++ b/vectordb_bench/backend/clients/weaviate_cloud/weaviate_cloud.py
@@ -1,14 +1,13 @@
 """Wrapper around the Weaviate vector database over VectorDB"""
 
 import logging
-from typing import Iterable, Type
+from typing import Iterable
 from contextlib import contextmanager
 
+import weaviate
 from weaviate.exceptions import WeaviateBaseError
 
-from ..api import VectorDB, DBConfig, DBCaseConfig, IndexType
-from .config import WeaviateConfig, WeaviateIndexConfig
-
+from ..api import VectorDB, DBCaseConfig
 
 log = logging.getLogger(__name__)
 
@@ -24,6 +23,7 @@ class WeaviateCloud(VectorDB):
         **kwargs,
     ):
         """Initialize wrapper around the weaviate vector database."""
+        db_config.update("auth_client_secret", weaviate.AuthApiKey(api_key=db_config.get("auth_client_secret")))
         self.db_config = db_config
         self.case_config = db_case_config
         self.collection_name = collection_name
@@ -44,14 +44,6 @@ class WeaviateCloud(VectorDB):
                 raise e from None
         self._create_collection(client)
         client = None
-
-    @classmethod
-    def config_cls(cls) -> Type[DBConfig]:
-        return WeaviateConfig
-
-    @classmethod
-    def case_config_cls(cls, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return WeaviateIndexConfig
 
     @contextmanager
     def init(self) -> None:

--- a/vectordb_bench/backend/clients/zilliz_cloud/zilliz_cloud.py
+++ b/vectordb_bench/backend/clients/zilliz_cloud/zilliz_cloud.py
@@ -1,9 +1,7 @@
 """Wrapper around the ZillizCloud vector database over VectorDB"""
 
-from typing import Type
 from ..milvus.milvus import Milvus
-from ..api import DBConfig, DBCaseConfig, IndexType
-from .config import ZillizCloudConfig, AutoIndexConfig
+from ..api import DBCaseConfig
 
 
 class ZillizCloud(Milvus):
@@ -15,7 +13,7 @@ class ZillizCloud(Milvus):
         collection_name: str = "ZillizCloudVectorDBBench",
         drop_old: bool = False,
         name: str = "ZillizCloud",
-        **kwargs, 
+        **kwargs,
     ):
         super().__init__(
             dim=dim,
@@ -26,12 +24,3 @@ class ZillizCloud(Milvus):
             name=name,
             **kwargs,
         )
-
-    @classmethod
-    def config_cls(cls) -> Type[DBConfig]:
-        return ZillizCloudConfig
-
-
-    @classmethod
-    def case_config_cls(cls, index_type: IndexType | None = None) -> Type[DBCaseConfig]:
-        return AutoIndexConfig

--- a/vectordb_bench/frontend/components/run_test/dbConfigSetting.py
+++ b/vectordb_bench/frontend/components/run_test/dbConfigSetting.py
@@ -16,7 +16,7 @@ def dbConfigSettings(st, activedDbList):
         dbConfigSettingItemContainer = expander.container()
         dbConfig = dbConfigSettingItem(dbConfigSettingItemContainer, activeDb)
         try:
-            dbConfigs[activeDb] = activeDb.init_cls.config_cls()(**dbConfig)
+            dbConfigs[activeDb] = activeDb.config_cls(**dbConfig)
         except ValidationError as e:
             isAllValid = False
             errTexts = []
@@ -38,8 +38,7 @@ def dbConfigSettingItem(st, activeDb):
     )
     columns = st.columns(DB_CONFIG_SETTING_COLUMNS)
 
-    activeDbCls = activeDb.init_cls
-    dbConfigClass = activeDbCls.config_cls()
+    dbConfigClass = activeDb.config_cls
     properties = dbConfigClass.schema().get("properties")
     propertiesItems = list(properties.items())
     moveDBLabelToLast(propertiesItems)

--- a/vectordb_bench/frontend/components/run_test/generateTasks.py
+++ b/vectordb_bench/frontend/components/run_test/generateTasks.py
@@ -12,7 +12,7 @@ def generate_tasks(activedDbList, dbConfigs, activedCaseList, allCaseConfigs):
                         case_id=case.value,
                         custom_case={},
                     ),
-                    db_case_config=db.init_cls.case_config_cls(
+                    db_case_config=db.case_config_cls(
                         allCaseConfigs[db][case].get(CaseConfigParamType.IndexType, None)
                     )(**{key.value: value for key, value in allCaseConfigs[db][case].items()}),
                 )

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -144,12 +144,11 @@ class TestResult(BaseModel):
             for case_result in test_result["results"]:
                 task_config = case_result.get("task_config")
                 db = DB(task_config.get("db"))
-                dbcls = db.init_cls
 
-                task_config["db_config"] = dbcls.config_cls()(
+                task_config["db_config"] = db.config_cls(
                     **task_config["db_config"]
                 )
-                task_config["db_case_config"] = dbcls.case_config_cls(
+                task_config["db_case_config"] = db.case_config_cls(
                     index_type=task_config["db_case_config"].get("index", None),
                 )(**task_config["db_case_config"])
 


### PR DESCRIPTION
As we support more and more databases, vectordb-bench depends on more and more database clients, which causes some dependency problems. Especially when we only cares for one or two databases.

This PR removes the dependency of all database clients. We are still able to browse the standard results with no database clients installed.

And we can install the database clients when we need to do benchmarks on the sepcific database.

1. The defatul vectordb-bench now only contains PyMilvus

        pip install vectordb-bench # pymilvus only

2. We can still install all database clients 

        pip install vectordb-bench[all]

4. Or some other database client

        pip install vectordb-bench[pinecone]