### PR TITLE
Add minute to task label to avoid result overwrite within an hour

### DIFF
--- a/vectordb_bench/frontend/components/run_test/submitTask.py
+++ b/vectordb_bench/frontend/components/run_test/submitTask.py
@@ -26,7 +26,7 @@ def submitTask(st, tasks, isAllValid):
 
 
 def taskLabelInput(st):
-    defaultTaskLabel = datetime.now().strftime("%Y%m%d%H")
+    defaultTaskLabel = datetime.now().strftime("%Y%m%d%H%M")
     columns = st.columns(TASK_LABEL_INPUT_COLUMNS)
     taskLabel = columns[0].text_input(
         "task_label", defaultTaskLabel, label_visibility="collapsed"


### PR DESCRIPTION
After we get data prepared, we usually will do multiple perf tests within an hour, it is annoying that the result file would be overwrote, so we can add minute to it to avoid this problem. And we may not run multiple tests within a minute btw:)