### PR TITLE
support gpu_index_type for milvus

### DIFF
--- a/vectordb_bench/__init__.py
+++ b/vectordb_bench/__init__.py
@@ -16,6 +16,7 @@ class config:
 
     DROP_OLD = env.bool("DROP_OLD", True)
     USE_SHUFFLED_DATA = env.bool("USE_SHUFFLED_DATA", True)
+    NUM_CONCURRENCY = [1, 5, 10, 15, 20, 25, 30, 35]
 
     RESULTS_LOCAL_DIR = pathlib.Path(__file__).parent.joinpath("results")
 

--- a/vectordb_bench/backend/clients/api.py
+++ b/vectordb_bench/backend/clients/api.py
@@ -19,6 +19,9 @@ class IndexType(str, Enum):
     Flat = "FLAT"
     AUTOINDEX = "AUTOINDEX"
     ES_HNSW = "hnsw"
+    GPU_IVF_FLAT = "GPU_IVF_FLAT"
+    GPU_IVF_PQ = "GPU_IVF_PQ"
+    GPU_CAGRA = "GPU_CAGRA"
 
 
 class DBConfig(ABC, BaseModel):
@@ -49,6 +52,7 @@ class DBConfig(ABC, BaseModel):
 
 class DBCaseConfig(ABC):
     """Case specific vector database configs, usually uesed for index params like HNSW"""
+
     @abstractmethod
     def index_param(self) -> dict:
         raise NotImplementedError
@@ -60,7 +64,9 @@ class DBCaseConfig(ABC):
 
 class EmptyDBCaseConfig(BaseModel, DBCaseConfig):
     """EmptyDBCaseConfig will be used if the vector database has no case specific configs"""
+
     null: str | None = None
+
     def index_param(self) -> dict:
         return {}
 
@@ -108,7 +114,7 @@ class VectorDB(ABC):
     @abstractmethod
     @contextmanager
     def init(self) -> None:
-        """ create and destory connections to database.
+        """create and destory connections to database.
 
         Examples:
             >>> with self.init():

--- a/vectordb_bench/backend/clients/milvus/config.py
+++ b/vectordb_bench/backend/clients/milvus/config.py
@@ -19,8 +19,8 @@ class MilvusIndexConfig(BaseModel):
         if not self.metric_type:
             return ""
 
-        if self.metric_type == MetricType.COSINE:
-            return MetricType.L2.value
+        # if self.metric_type == MetricType.COSINE:
+        #     return MetricType.L2.value
         return self.metric_type.value
 
 
@@ -38,6 +38,7 @@ class AutoIndexConfig(MilvusIndexConfig, DBCaseConfig):
         return {
             "metric_type": self.parse_metric(),
         }
+
 
 class HNSWConfig(MilvusIndexConfig, DBCaseConfig):
     M: int
@@ -112,11 +113,87 @@ class FLATConfig(MilvusIndexConfig, DBCaseConfig):
             "params": {},
         }
 
+
+class GPUIVFFlatConfig(MilvusIndexConfig, DBCaseConfig):
+    nlist: int = 1024
+    nprobe: int = 64
+    index: IndexType = IndexType.GPU_IVF_FLAT
+
+    def index_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "index_type": self.index.value,
+            "params": {"nlist": self.nlist},
+        }
+
+    def search_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "params": {"nprobe": self.nprobe},
+        }
+
+
+class GPUIVFPQConfig(MilvusIndexConfig, DBCaseConfig):
+    nlist: int = 1024
+    m: int = 0
+    nbits: int = 8
+    nprobe: int = 32
+    index: IndexType = IndexType.GPU_IVF_PQ
+
+    def index_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "index_type": self.index.value,
+            "params": {"nlist": self.nlist, "m": self.m, "nbits": self.nbits},
+        }
+
+    def search_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "params": {"nprobe": self.nprobe},
+        }
+
+
+class GPUCAGRAConfig(MilvusIndexConfig, DBCaseConfig):
+    intermediate_graph_degree: int = 64
+    graph_degree: int = 32
+    itopk_size: int = 128
+    team_size: int = 0
+    search_width: int = 4
+    min_iterations: int = 0
+    max_iterations: int = 0
+    index: IndexType = IndexType.GPU_CAGRA
+
+    def index_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "index_type": self.index.value,
+            "params": {
+                "intermediate_graph_degree": self.intermediate_graph_degree,
+                "graph_degree": self.graph_degree,
+            },
+        }
+
+    def search_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "params": {
+                "team_size": self.team_size,
+                "search_width": self.search_width,
+                "itopk_size": self.itopk_size,
+                "min_iterations": self.min_iterations,
+                "max_iterations": self.max_iterations,
+            },
+        }
+
+
 _milvus_case_config = {
     IndexType.AUTOINDEX: AutoIndexConfig,
     IndexType.HNSW: HNSWConfig,
     IndexType.DISKANN: DISKANNConfig,
     IndexType.IVFFlat: IVFFlatConfig,
     IndexType.Flat: FLATConfig,
+    IndexType.GPU_IVF_FLAT: GPUIVFFlatConfig,
+    IndexType.GPU_IVF_PQ: GPUIVFPQConfig,
+    IndexType.GPU_CAGRA: GPUCAGRAConfig,
 }
-

--- a/vectordb_bench/backend/clients/milvus/milvus.py
+++ b/vectordb_bench/backend/clients/milvus/milvus.py
@@ -151,7 +151,7 @@ class Milvus(VectorDB):
 
     def need_normalize_cosine(self) -> bool:
         """Wheather this database need to normalize dataset to support COSINE"""
-        return True
+        return False
 
     def insert_embeddings(
         self,

--- a/vectordb_bench/backend/runner/mp_runner.py
+++ b/vectordb_bench/backend/runner/mp_runner.py
@@ -26,7 +26,7 @@ class MultiProcessingSearchRunner:
         test_data: list[list[float]],
         k: int = 100,
         filters: dict | None = None,
-        concurrencies: Iterable[int] = (1, 5, 10, 15, 20, 25, 30, 35),
+        concurrencies: Iterable[int] = config.NUM_CONCURRENCY,
         duration: int = 30,
     ):
         self.db = db

--- a/vectordb_bench/frontend/const/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/const/dbCaseConfigs.py
@@ -63,6 +63,9 @@ CaseConfigParamInput_IndexType = CaseConfigInput(
             IndexType.DISKANN.value,
             IndexType.Flat.value,
             IndexType.AUTOINDEX.value,
+            IndexType.GPU_IVF_FLAT.value,
+            IndexType.GPU_IVF_PQ.value,
+            IndexType.GPU_CAGRA.value,
         ],
     },
 )
@@ -189,10 +192,14 @@ CaseConfigParamInput_Nlist = CaseConfigInput(
     inputConfig={
         "min": 1,
         "max": 65536,
-        "value": 1000,
+        "value": 1024,
     },
     isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
-    == IndexType.IVFFlat.value,
+    in [
+        IndexType.IVFFlat.value,
+        IndexType.GPU_IVF_FLAT.value,
+        IndexType.GPU_IVF_PQ.value,
+    ],
 )
 
 CaseConfigParamInput_Nprobe = CaseConfigInput(
@@ -201,10 +208,122 @@ CaseConfigParamInput_Nprobe = CaseConfigInput(
     inputConfig={
         "min": 1,
         "max": 65536,
-        "value": 10,
+        "value": 64,
     },
     isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
-    == IndexType.IVFFlat.value,
+    in [
+        IndexType.IVFFlat.value,
+        IndexType.GPU_IVF_FLAT.value,
+        IndexType.GPU_IVF_PQ.value,
+    ],
+)
+
+CaseConfigParamInput_M_PQ = CaseConfigInput(
+    label=CaseConfigParamType.m,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 0,
+        "max": 65536,
+        "value": 0,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_IVF_PQ.value],
+)
+
+CaseConfigParamInput_Nbits_PQ = CaseConfigInput(
+    label=CaseConfigParamType.nbits,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 1,
+        "max": 65536,
+        "value": 8,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_IVF_PQ.value],
+)
+
+CaseConfigParamInput_intermediate_graph_degree = CaseConfigInput(
+    label=CaseConfigParamType.intermediate_graph_degree,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 1,
+        "max": 65536,
+        "value": 64,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_CAGRA.value],
+)
+
+CaseConfigParamInput_graph_degree = CaseConfigInput(
+    label=CaseConfigParamType.graph_degree,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 1,
+        "max": 65536,
+        "value": 32,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_CAGRA.value],
+)
+
+CaseConfigParamInput_itopk_size = CaseConfigInput(
+    label=CaseConfigParamType.itopk_size,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 1,
+        "max": 65536,
+        "value": 128,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_CAGRA.value],
+)
+
+CaseConfigParamInput_team_size = CaseConfigInput(
+    label=CaseConfigParamType.team_size,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 0,
+        "max": 65536,
+        "value": 0,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_CAGRA.value],
+)
+
+CaseConfigParamInput_search_width = CaseConfigInput(
+    label=CaseConfigParamType.search_width,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 0,
+        "max": 65536,
+        "value": 4,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_CAGRA.value],
+)
+
+CaseConfigParamInput_min_iterations = CaseConfigInput(
+    label=CaseConfigParamType.min_iterations,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 0,
+        "max": 65536,
+        "value": 0,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_CAGRA.value],
+)
+
+CaseConfigParamInput_max_iterations = CaseConfigInput(
+    label=CaseConfigParamType.max_iterations,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 0,
+        "max": 65536,
+        "value": 0,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None)
+    in [IndexType.GPU_CAGRA.value],
 )
 
 CaseConfigParamInput_Lists = CaseConfigInput(
@@ -250,6 +369,10 @@ MilvusLoadConfig = [
     CaseConfigParamInput_M,
     CaseConfigParamInput_EFConstruction_Milvus,
     CaseConfigParamInput_Nlist,
+    CaseConfigParamInput_M_PQ,
+    CaseConfigParamInput_Nbits_PQ,
+    CaseConfigParamInput_intermediate_graph_degree,
+    CaseConfigParamInput_graph_degree,
 ]
 MilvusPerformanceConfig = [
     CaseConfigParamInput_IndexType,
@@ -259,6 +382,15 @@ MilvusPerformanceConfig = [
     CaseConfigParamInput_SearchList,
     CaseConfigParamInput_Nlist,
     CaseConfigParamInput_Nprobe,
+    CaseConfigParamInput_M_PQ,
+    CaseConfigParamInput_Nbits_PQ,
+    CaseConfigParamInput_intermediate_graph_degree,
+    CaseConfigParamInput_graph_degree,
+    CaseConfigParamInput_itopk_size,
+    CaseConfigParamInput_team_size,
+    CaseConfigParamInput_search_width,
+    CaseConfigParamInput_min_iterations,
+    CaseConfigParamInput_max_iterations,
 ]
 
 WeaviateLoadConfig = [


### PR DESCRIPTION
- Add more index_type for milvus
  - GPU_IVF_FLAT 
![image](https://github.com/zilliztech/VectorDBBench/assets/22510720/0cb4f259-ac5d-4362-bf62-b9edeab92c83)
  - GPU_IVF_PQ
![image](https://github.com/zilliztech/VectorDBBench/assets/22510720/b724e99f-230f-44a9-b896-8fb4d82c4985)
  - GPU_CAGRA
![image](https://github.com/zilliztech/VectorDBBench/assets/22510720/9ac22f6c-cd9a-4015-a331-26a33974e695)

- Milvus support cosine metric
- The number of **concurrent threads** for performance tests can be set in `./vectordb_bench/__init__.py`
  - default: `NUM_CONCURRENCY = [1, 5, 10, 15, 20, 25, 30, 35]`