### PR TITLE
add new db_config for better labeling: version, note

### DIFF
--- a/vectordb_bench/backend/clients/api.py
+++ b/vectordb_bench/backend/clients/api.py
@@ -38,6 +38,22 @@ class DBConfig(ABC, BaseModel):
     """
 
     db_label: str = ""
+    version: str = ""
+    note: str = ""
+
+    @staticmethod
+    def common_short_configs() -> list[str]:
+        """
+        short input, such as `db_label`, `version`
+        """
+        return ["version", "db_label"]
+
+    @staticmethod
+    def common_long_configs() -> list[str]:
+        """
+        long input, such as `note`
+        """
+        return ["note"]
 
     @abstractmethod
     def to_dict(self) -> dict:
@@ -45,7 +61,10 @@ class DBConfig(ABC, BaseModel):
 
     @validator("*")
     def not_empty_field(cls, v, field):
-        if field.name == "db_label":
+        if (
+            field.name in cls.common_short_configs()
+            or field.name in cls.common_long_configs()
+        ):
             return v
         if not v and isinstance(v, (str, SecretStr)):
             raise ValueError("Empty string!")

--- a/vectordb_bench/frontend/components/check_results/data.py
+++ b/vectordb_bench/frontend/components/check_results/data.py
@@ -24,7 +24,10 @@ def getFilterTasks(
         task
         for task in tasks
         if task.task_config.db_name in dbNames
-        and task.task_config.case_config.case_id.case_cls(task.task_config.case_config.custom_case).name in caseNames
+        and task.task_config.case_config.case_id.case_cls(
+            task.task_config.case_config.custom_case
+        ).name
+        in caseNames
     ]
     return filterTasks
 
@@ -35,17 +38,20 @@ def mergeTasks(tasks: list[CaseResult]):
         db_name = task.task_config.db_name
         db = task.task_config.db.value
         db_label = task.task_config.db_config.db_label or ""
-        case = task.task_config.case_config.case_id.case_cls(task.task_config.case_config.custom_case)
+        version = task.task_config.db_config.version or ""
+        case = task.task_config.case_config.case_id.case_cls(
+            task.task_config.case_config.custom_case
+        )
         dbCaseMetricsMap[db_name][case.name] = {
             "db": db,
             "db_label": db_label,
+            "version": version,
             "metrics": mergeMetrics(
                 dbCaseMetricsMap[db_name][case.name].get("metrics", {}),
                 asdict(task.metrics),
             ),
             "label": getBetterLabel(
-                dbCaseMetricsMap[db_name][case.name].get(
-                    "label", ResultLabel.FAILED),
+                dbCaseMetricsMap[db_name][case.name].get("label", ResultLabel.FAILED),
                 task.label,
             ),
         }
@@ -57,6 +63,7 @@ def mergeTasks(tasks: list[CaseResult]):
             metrics = metricInfo["metrics"]
             db = metricInfo["db"]
             db_label = metricInfo["db_label"]
+            version = metricInfo["version"]
             label = metricInfo["label"]
             if label == ResultLabel.NORMAL:
                 mergedTasks.append(
@@ -64,6 +71,7 @@ def mergeTasks(tasks: list[CaseResult]):
                         "db_name": db_name,
                         "db": db,
                         "db_label": db_label,
+                        "version": version,
                         "case_name": case_name,
                         "metricsSet": set(metrics.keys()),
                         **metrics,
@@ -79,8 +87,7 @@ def mergeMetrics(metrics_1: dict, metrics_2: dict) -> dict:
     metrics = {**metrics_1}
     for key, value in metrics_2.items():
         metrics[key] = (
-            getBetterMetric(
-                key, value, metrics[key]) if key in metrics else value
+            getBetterMetric(key, value, metrics[key]) if key in metrics else value
         )
 
     return metrics

--- a/vectordb_bench/frontend/components/run_test/initStyle.py
+++ b/vectordb_bench/frontend/components/run_test/initStyle.py
@@ -9,6 +9,8 @@ def initStyle(st):
             div[data-testid='stHorizontalBlock'] {gap: 8px;}
             /* check box */
             .stCheckbox p { color: #000; font-size: 18px; font-weight: 600; }
+            /* db selector - db_name should not wrap */
+            div[data-testid="stVerticalBlockBorderWrapper"] div[data-testid="stCheckbox"] div[data-testid="stWidgetLabel"] p { white-space: nowrap; }
         </style>""",
         unsafe_allow_html=True,
     )

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -2,7 +2,7 @@ import logging
 import pathlib
 from datetime import date
 from enum import Enum, StrEnum, auto
-from typing import List, Self, Sequence, Set
+from typing import List, Self
 
 import ujson
 
@@ -10,7 +10,6 @@ from .backend.clients import (
     DB,
     DBConfig,
     DBCaseConfig,
-    IndexType,
 )
 from .backend.cases import CaseType
 from .base import BaseModel
@@ -128,9 +127,14 @@ class TaskConfig(BaseModel):
 
     @property
     def db_name(self):
-        db = self.db.value
+        db_name = f"{self.db.value}"
         db_label = self.db_config.db_label
-        return f"{db}-{db_label}" if db_label else db
+        if db_label:
+            db_name += f"-{db_label}"
+        version = self.db_config.version
+        if version:
+            db_name += f"-{version}"
+        return db_name
 
 
 class ResultLabel(Enum):


### PR DESCRIPTION
- `version` is optional and used to label db. 
  - `db_name` will be displayed as `db + db_label + version`, e.g. from `Milvus-2c8g-hnsw` to `Milvus-2c8g-hnsw-v2.2.16`
- `note` is optional and used to record any information the user wishes to preserve. 
  - it will only be logged to the result file and not displayed currently.

![image](https://github.com/user-attachments/assets/502f5325-692a-4001-b4fe-53504956e12e)
