### PR TITLE
pgvecto.rs: upgrade pgvecto.rs sdk to v0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ all = [
     "weaviate-client",
     "elasticsearch",
     "pgvector",
-    "pgvecto_rs[psycopg3]>=0.2.1",
+    "pgvecto_rs[psycopg3]>=0.2.2",
     "sqlalchemy",
     "redis",
     "chromadb",
@@ -72,7 +72,7 @@ weaviate = [ "weaviate-client" ]
 elastic = [ "elasticsearch" ]
 pgvector = [ "psycopg", "psycopg-binary", "pgvector" ]
 pgvectorscale = [ "psycopg", "psycopg-binary", "pgvector" ]
-pgvecto_rs = [ "pgvecto_rs[psycopg3]>=0.2.1" ]
+pgvecto_rs = [ "pgvecto_rs[psycopg3]>=0.2.2" ]
 redis = [ "redis" ]
 memorydb = [ "memorydb" ]
 chromadb = [ "chromadb" ]


### PR DESCRIPTION
Here we introduce a bug fix for `PGVecto.rs >= 0.4.0`

If we don't need quantization, we pick a `trivial` option at WebUI, and this is the default behavior.

In `pgvecto.rs sdk = 0.2.1`, it will be translated into `[indexing.ivf.quantization.trivial]` or `[indexing.hnsw.quantization.trivial]` as toml config.

https://github.com/tensorchord/pgvecto.rs-py/blob/5e175a981b36fbb671033c2db45636a11d6dc04f/tests/__init__.py#L108

But we have a breaking change in `PGVecto.rs 0.4.0`, that it would not accept trivial quantization config. To express no quantization, `quantization` should not be showed in config.

So `pgvecto.rs sdk = 0.2.2` change the behavior that will translate `trivial` option into `[indexing.ivf]` or `[indexing.hnsw]`.

https://github.com/tensorchord/pgvecto.rs-py/blob/5bc6fc34f2d0df05701000f298596587d58acc99/tests/__init__.py#L108

This is a transparent compile inside SDK, and forward compatibility, so there is nothing to do for VectorDBBench except a upgrade.