### PR TITLE
Randomly pick start idx of test dataset in concurrency search.

### DIFF
--- a/vectordb_bench/backend/runner/mp_runner.py
+++ b/vectordb_bench/backend/runner/mp_runner.py
@@ -2,6 +2,7 @@ import time
 import traceback
 import concurrent
 import multiprocessing as mp
+import random
 import logging
 from typing import Iterable
 import numpy as np
@@ -46,7 +47,7 @@ class MultiProcessingSearchRunner:
             cond.wait()
 
         with self.db.init():
-            num, idx = len(test_data), 0
+            num, idx = len(test_data), random.randint(0, len(test_data) - 1)
 
             start_time = time.perf_counter()
             count = 0


### PR DESCRIPTION
In the current implementation of concurrent search, all threads begin querying the test dataset starting at index 0 and proceed sequentially through the dataset (looping multiple times). As a consequence, all threads are making the same query to the database almost at the same time. To make it more realistic the PR starts each query from a different starting index, resulting it different threads running different queries.
Databases like Postgres, rely on storing the data/index on disk and loading it on demand in memory. In case of constraint memory, where index doesn’t fit in memory, the first query typically hits the table, but subsequent queries are served from the index cached in shared_buffers. This skews performance metrics by making it difficult to observe the true cost of querying uncached data.
Note that there is no ramp-up or pre-warming step in VectorDBBench. However, there is a serial search task during which recall is calculated, where the set of 1000 queries is executed (this is the same set that is queried during the conc search). Therefore, the relevant index should already be present in memory, if enough memory is there. However, in case memory is not large enough to hold the index, it makes sense that randomizing the idx will result it more realistic numbers.

In summary, if index fits in memory, then this and previous approach would give same QPS. However in case index > memory, QPS numbers with these changes will decrease as different threads are executing different queries at the same time and to accommodate the index in memory certain data needs to be evicted.

Tested on:
Database: Postgres
Algo: pgvectorhnsw