### PR TITLE
Fix pgvectorivfflat reranking key bug

### DIFF
--- a/vectordb_bench/backend/clients/pgvector/cli.py
+++ b/vectordb_bench/backend/clients/pgvector/cli.py
@@ -136,6 +136,9 @@ def PgVectorIVFFlat(
             lists=parameters["lists"],
             probes=parameters["probes"],
             quantization_type=parameters["quantization_type"],
+            reranking=parameters["reranking"],
+            reranking_metric=parameters["reranking_metric"],
+            quantized_fetch_limit=parameters["quantized_fetch_limit"],
         ),
         **parameters,
     )

--- a/vectordb_bench/backend/clients/pgvector/cli.py
+++ b/vectordb_bench/backend/clients/pgvector/cli.py
@@ -18,11 +18,12 @@ from ....cli.cli import (
 from vectordb_bench.backend.clients import DB
 
 
-
 def set_default_quantized_fetch_limit(ctx, param, value):
     if ctx.params.get("reranking") and value is None:
         # ef_search is the default value for quantized_fetch_limit as it's bound by ef_search.
-        return ctx.params["ef_search"] 
+        # 100 (arbitrary) is default value for quantized_fetch_limit for IVFFlat.
+        default_value = ctx.params["ef_search"] if ctx.command.name == "pgvectorhnsw" else 100
+        return default_value
     return value
 
 class PgVectorTypedDict(CommonTypedDict):

--- a/vectordb_bench/backend/clients/pgvector/cli.py
+++ b/vectordb_bench/backend/clients/pgvector/cli.py
@@ -21,7 +21,7 @@ from vectordb_bench.backend.clients import DB
 def set_default_quantized_fetch_limit(ctx, param, value):
     if ctx.params.get("reranking") and value is None:
         # ef_search is the default value for quantized_fetch_limit as it's bound by ef_search.
-        # 100 (arbitrary) is default value for quantized_fetch_limit for IVFFlat.
+        # 100 is default value for quantized_fetch_limit for IVFFlat.
         default_value = ctx.params["ef_search"] if ctx.command.name == "pgvectorhnsw" else 100
         return default_value
     return value

--- a/vectordb_bench/backend/clients/pgvector/config.py
+++ b/vectordb_bench/backend/clients/pgvector/config.py
@@ -168,6 +168,9 @@ class PgVectorIVFFlatConfig(PgVectorIndexConfig):
     maintenance_work_mem: Optional[str] = None
     max_parallel_workers: Optional[int] = None
     quantization_type: Optional[str] = None
+    reranking: Optional[bool] = None
+    quantized_fetch_limit: Optional[int] = None
+    reranking_metric: Optional[str] = None
 
     def index_param(self) -> PgVectorIndexParam:
         index_parameters = {"lists": self.lists}
@@ -187,6 +190,9 @@ class PgVectorIVFFlatConfig(PgVectorIndexConfig):
     def search_param(self) -> PgVectorSearchParam:
         return {
             "metric_fun_op": self.parse_metric_fun_op(),
+            "reranking": self.reranking,
+            "reranking_metric_fun_op": self.parse_reranking_metric_fun_op(),
+            "quantized_fetch_limit": self.quantized_fetch_limit,
         }
 
     def session_param(self) -> PgVectorSessionCommands:

--- a/vectordb_bench/cli/cli.py
+++ b/vectordb_bench/cli/cli.py
@@ -414,7 +414,7 @@ class HNSWBaseRequiredTypedDict(TypedDict):
 
 class HNSWFlavor1(HNSWBaseTypedDict):
     ef_search: Annotated[
-        Optional[int], click.option("--ef-search", type=int, help="hnsw ef-search")
+        Optional[int], click.option("--ef-search", type=int, help="hnsw ef-search", is_eager=True)
     ]
 
 


### PR DESCRIPTION
Issue: #398 

**Further related issues fixed:**
Fixed an issue where `quantized_fetch_limit` was defaulting to `ef_search`, which is not applicable to `ivfflat`. 
1. The default value of `quantized_fetch_limit` for `pgvectorhnsw` is now set to the value of `ef_search`.
2. For `pgvectorivfflat`, it’s set to 100 (chosen arbitrarily; users should update this based on their requirements).
