### PR TITLE
fix: invalid value for --max-num-levels when using CLI (AlloyDB)

### DIFF
--- a/vectordb_bench/backend/clients/alloydb/cli.py
+++ b/vectordb_bench/backend/clients/alloydb/cli.py
@@ -106,7 +106,7 @@ class AlloyDBScaNNTypedDict(AlloyDBTypedDict):
         int,
         click.option(
             "--max-num-levels",
-            type=click.Choice([1, 2]),
+            type=click.Choice(["1", "2"]),
             help="Maximum number of levels",
             default=1
         )


### PR DESCRIPTION
Fixed an issue, `click.choice()` only accepts `string` and `integers` were being passed previously.
Updated the values in the list passed to `click.choice()`  to `string`, the CLI option `--max-num-levels` is working now.