### PR TITLE
Opensearch interal configuration parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,22 +172,27 @@ $ vectordbbench awsopensearch --help
 Usage: vectordbbench awsopensearch [OPTIONS]
 
 Options:
-  --number-of-shards INTEGER      Number of shards
-  --number-of-replicas INTEGER    Number of replica
+  # Sharding and Replication
+  --number-of-shards INTEGER      Number of primary shards for the index
+  --number-of-replicas INTEGER    Number of replica copies for each primary
+                                  shard
+  # Indexing Performance                              
   --index-thread-qty INTEGER      Thread count for native engine indexing
   --index-thread-qty-during-force-merge INTEGER
-                                  Thread count for native engine indexing used
-                                  during force merge
-  --number-of-segments INTEGER    Number of segments
-  --refresh-interval TEXT         refresh-interval for the index
-  --force-merge-enabled BOOLEAN   If we need to do force merge or not
-  --flush-threshold-size TEXT     Threshold for flushing translog
+                                  Thread count during force merge operations
   --number-of-indexing-clients INTEGER
-                                  Number of indexing clients that should be
-                                  used for indexing the data
+                                  Number of concurrent indexing clients
+  # Index Management
+  --number-of-segments INTEGER    Target number of segments after merging
+  --refresh-interval TEXT         How often to make new data available for
+                                  search
+  --force-merge-enabled BOOLEAN   Whether to perform force merge operation
+  --flush-threshold-size TEXT     Size threshold for flushing the transaction
+                                  log
+  # Memory Management
   --cb-threshold TEXT             k-NN Memory circuit breaker threshold
-  --help                          Show this message and exit.
-```
+
+  --help                          Show this message and exit.```
 
 #### Using a configuration file.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,42 @@ Options:
                                   with-gt]
   --help                          Show this message and exit.
 ```
+
+### Run awsopensearch from command line
+
+```shell
+vectordbbench awsopensearch --db-label awsopensearch \
+--m 16 --ef-construction 256 \
+--host search-vector-db-prod-h4f6m4of6x7yp2rz7gdmots7w4.us-west-2.es.amazonaws.com --port 443 \
+--user vector --password '<password>' \
+--case-type Performance1536D5M --num-insert-workers 10  \
+--skip-load --num-concurrency 75
+```
+
+To list the options for awsopensearch, execute `vectordbbench awsopensearch --help`
+
+```text
+$ vectordbbench awsopensearch --help
+Usage: vectordbbench awsopensearch [OPTIONS]
+
+Options:
+  --number-of-shards INTEGER      Number of shards
+  --number-of-replicas INTEGER    Number of replica
+  --index-thread-qty INTEGER      Thread count for native engine indexing
+  --index-thread-qty-during-force-merge INTEGER
+                                  Thread count for native engine indexing used
+                                  during force merge
+  --number-of-segments INTEGER    Number of segments
+  --refresh-interval TEXT         refresh-interval for the index
+  --force-merge-enabled BOOLEAN   If we need to do force merge or not
+  --flush-threshold-size TEXT     Threshold for flushing translog
+  --number-of-indexing-clients INTEGER
+                                  Number of indexing clients that should be
+                                  used for indexing the data
+  --cb-threshold TEXT             k-NN Memory circuit breaker threshold
+  --help                          Show this message and exit.
+```
+
 #### Using a configuration file.
 
 The vectordbbench command can optionally read some or all the options from a yaml formatted configuration file.

--- a/vectordb_bench/backend/clients/aws_opensearch/cli.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/cli.py
@@ -20,11 +20,13 @@ class AWSOpenSearchTypedDict(TypedDict):
     password: Annotated[str, click.option("--password", type=str, help="Db password")]
     number_of_shards: Annotated[
         int,
-        click.option("--number-of-shards", type=int, help="Number of shards", default=1),
+        click.option("--number-of-shards", type=int, help="Number of primary shards for the index", default=1),
     ]
     number_of_replicas: Annotated[
         int,
-        click.option("--number-of-replicas", type=int, help="Number of replica", default=1),
+        click.option(
+            "--number-of-replicas", type=int, help="Number of replica copies for each primary shard", default=1
+        ),
     ]
     index_thread_qty: Annotated[
         int,
@@ -41,29 +43,9 @@ class AWSOpenSearchTypedDict(TypedDict):
         click.option(
             "--index-thread-qty-during-force-merge",
             type=int,
-            help="Thread count for native engine indexing used during force merge",
+            help="Thread count during force merge operations",
             default=4,
         ),
-    ]
-
-    number_of_segments: Annotated[
-        int,
-        click.option("--number-of-segments", type=int, help="Number of segments", default=1),
-    ]
-
-    refresh_interval: Annotated[
-        int,
-        click.option("--refresh-interval", type=str, help="refresh-interval", default="60s"),
-    ]
-
-    force_merge_enabled: Annotated[
-        int,
-        click.option("--force-merge-enabled", type=bool, help="If we need to do force merge or not", default=True),
-    ]
-
-    flush_threshold_size: Annotated[
-        int,
-        click.option("--flush-threshold-size", type=str, help="Threshold for flushing translog", default="5120mb"),
     ]
 
     number_of_indexing_clients: Annotated[
@@ -71,8 +53,32 @@ class AWSOpenSearchTypedDict(TypedDict):
         click.option(
             "--number-of-indexing-clients",
             type=int,
-            help="Number of indexing clients that should be used for indexing the data",
+            help="Number of concurrent indexing clients",
             default=1,
+        ),
+    ]
+
+    number_of_segments: Annotated[
+        int,
+        click.option("--number-of-segments", type=int, help="Target number of segments after merging", default=1),
+    ]
+
+    refresh_interval: Annotated[
+        int,
+        click.option(
+            "--refresh-interval", type=str, help="How often to make new data available for search", default="60s"
+        ),
+    ]
+
+    force_merge_enabled: Annotated[
+        int,
+        click.option("--force-merge-enabled", type=bool, help="Whether to perform force merge operation", default=True),
+    ]
+
+    flush_threshold_size: Annotated[
+        int,
+        click.option(
+            "--flush-threshold-size", type=str, help="Size threshold for flushing the transaction log", default="5120mb"
         ),
     ]
 

--- a/vectordb_bench/backend/clients/aws_opensearch/cli.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/cli.py
@@ -18,6 +18,73 @@ class AWSOpenSearchTypedDict(TypedDict):
     port: Annotated[int, click.option("--port", type=int, default=443, help="Db Port")]
     user: Annotated[str, click.option("--user", type=str, default="admin", help="Db User")]
     password: Annotated[str, click.option("--password", type=str, help="Db password")]
+    number_of_shards: Annotated[
+        int,
+        click.option("--number-of-shards", type=int, help="Number of shards", default=1),
+    ]
+    number_of_replicas: Annotated[
+        int,
+        click.option("--number-of-replicas", type=int, help="Number of replica", default=1),
+    ]
+    index_thread_qty: Annotated[
+        int,
+        click.option(
+            "--index-thread-qty",
+            type=int,
+            help="Thread count for native engine indexing",
+            default=4,
+        ),
+    ]
+
+    index_thread_qty_during_force_merge: Annotated[
+        int,
+        click.option(
+            "--index-thread-qty-during-force-merge",
+            type=int,
+            help="Thread count for native engine indexing used during force merge",
+            default=4,
+        ),
+    ]
+
+    number_of_segments: Annotated[
+        int,
+        click.option("--number-of-segments", type=int, help="Number of segments", default=1),
+    ]
+
+    refresh_interval: Annotated[
+        int,
+        click.option("--refresh-interval", type=str, help="refresh-interval", default="60s"),
+    ]
+
+    force_merge_enabled: Annotated[
+        int,
+        click.option("--force-merge-enabled", type=bool, help="If we need to do force merge or not", default=True),
+    ]
+
+    flush_threshold_size: Annotated[
+        int,
+        click.option("--flush-threshold-size", type=str, help="Threshold for flushing translog", default="5120mb"),
+    ]
+
+    number_of_indexing_clients: Annotated[
+        int,
+        click.option(
+            "--number-of-indexing-clients",
+            type=int,
+            help="Number of indexing clients that should be used for indexing the data",
+            default=1,
+        ),
+    ]
+
+    cb_threshold: Annotated[
+        int,
+        click.option(
+            "--cb-threshold",
+            type=str,
+            help="k-NN Memory circuit breaker threshold",
+            default="50%",
+        ),
+    ]
 
 
 class AWSOpenSearchHNSWTypedDict(CommonTypedDict, AWSOpenSearchTypedDict, HNSWFlavor2): ...
@@ -36,6 +103,17 @@ def AWSOpenSearch(**parameters: Unpack[AWSOpenSearchHNSWTypedDict]):
             user=parameters["user"],
             password=SecretStr(parameters["password"]),
         ),
-        db_case_config=AWSOpenSearchIndexConfig(),
+        db_case_config=AWSOpenSearchIndexConfig(
+            number_of_shards=parameters["number_of_shards"],
+            number_of_replicas=parameters["number_of_replicas"],
+            index_thread_qty=parameters["index_thread_qty"],
+            number_of_segments=parameters["number_of_segments"],
+            refresh_interval=parameters["refresh_interval"],
+            force_merge_enabled=parameters["force_merge_enabled"],
+            flush_threshold_size=parameters["flush_threshold_size"],
+            number_of_indexing_clients=parameters["number_of_indexing_clients"],
+            index_thread_qty_during_force_merge=parameters["index_thread_qty_during_force_merge"],
+            cb_threshold=parameters["cb_threshold"],
+        ),
         **parameters,
     )

--- a/vectordb_bench/backend/clients/aws_opensearch/config.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/config.py
@@ -39,6 +39,16 @@ class AWSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
     efConstruction: int = 256
     efSearch: int = 256
     M: int = 16
+    index_thread_qty: int | None = 4
+    number_of_shards: int | None = 1
+    number_of_replicas: int | None = 0
+    number_of_segments: int | None = 1
+    refresh_interval: str | None = "60s"
+    force_merge_enabled: bool | None = True
+    flush_threshold_size: str | None = "5120mb"
+    number_of_indexing_clients: int | None = 1
+    index_thread_qty_during_force_merge: int
+    cb_threshold: str | None = "50%"
 
     def parse_metric(self) -> str:
         if self.metric_type == MetricType.IP:


### PR DESCRIPTION
Added the configuration parameters to create Opensearch dynamically with right replicas, shards and other opensearch related configurations.

Added the feature to create OS index with 0 replica and once the data is loaded update the replicas according to the parameter.