### PR TITLE
Support GPU_BRUTE_FORCE index for Milvus

### DIFF
--- a/vectordb_bench/backend/clients/api.py
+++ b/vectordb_bench/backend/clients/api.py
@@ -25,6 +25,7 @@ class IndexType(str, Enum):
     ES_HNSW = "hnsw"
     ES_IVFFlat = "ivfflat"
     GPU_IVF_FLAT = "GPU_IVF_FLAT"
+    GPU_BRUTE_FORCE = "GPU_BRUTE_FORCE"
     GPU_IVF_PQ = "GPU_IVF_PQ"
     GPU_CAGRA = "GPU_CAGRA"
     SCANN = "scann"

--- a/vectordb_bench/backend/clients/milvus/cli.py
+++ b/vectordb_bench/backend/clients/milvus/cli.py
@@ -194,6 +194,26 @@ def MilvusGPUIVFFlat(**parameters: Unpack[MilvusGPUIVFTypedDict]):
         **parameters,
     )
 
+@cli.command()
+@click_parameter_decorators_from_typed_dict(MilvusGPUBruteForceTypedDict)
+def MilvusGPUBruteForce(**parameters: Unpack[MilvusGPUBruteForceTypedDict]):
+    from .config import GPUBruteForceConfig, MilvusConfig
+
+    run(
+        db=DBTYPE,
+        db_config=MilvusConfig(
+            db_label=parameters["db_label"],
+            uri=SecretStr(parameters["uri"]),
+            user=parameters["user_name"],
+            password=SecretStr(parameters["password"]),
+        ),
+        db_case_config=GPUBruteForceConfig(
+            metric_type=parameters["metric_type"],
+            limit=parameters["limit"],  # top-k for search
+        ),
+        **parameters,
+    )
+
 
 class MilvusGPUIVFPQTypedDict(
     CommonTypedDict,

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -173,6 +173,7 @@ CaseConfigParamInput_IndexType = CaseConfigInput(
             IndexType.GPU_IVF_FLAT.value,
             IndexType.GPU_IVF_PQ.value,
             IndexType.GPU_CAGRA.value,
+            IndexType.GPU_BRUTE_FORCE.value,
         ],
     },
 )
@@ -562,6 +563,7 @@ CaseConfigParamInput_Nlist = CaseConfigInput(
         IndexType.IVFSQ8.value,
         IndexType.GPU_IVF_FLAT.value,
         IndexType.GPU_IVF_PQ.value,
+        IndexType.GPU_BRUTE_FORCE.value,
     ],
 )
 
@@ -579,6 +581,7 @@ CaseConfigParamInput_Nprobe = CaseConfigInput(
         IndexType.IVFSQ8.value,
         IndexType.GPU_IVF_FLAT.value,
         IndexType.GPU_IVF_PQ.value,
+        IndexType.GPU_BRUTE_FORCE.value,
     ],
 )
 
@@ -703,6 +706,7 @@ CaseConfigParamInput_cache_dataset_on_device = CaseConfigInput(
         IndexType.GPU_CAGRA.value,
         IndexType.GPU_IVF_PQ.value,
         IndexType.GPU_IVF_FLAT.value,
+        IndexType.GPU_BRUTE_FORCE.value,
     ],
 )
 
@@ -720,6 +724,7 @@ CaseConfigParamInput_refine_ratio = CaseConfigInput(
         IndexType.GPU_CAGRA.value,
         IndexType.GPU_IVF_PQ.value,
         IndexType.GPU_IVF_FLAT.value,
+        IndexType.GPU_BRUTE_FORCE.value,
     ],
 )
 


### PR DESCRIPTION
GPU_BRUTE_FORCE is tailored for cases where extremely high recall is crucial, guaranteeing a recall of 1 by comparing each query with all vectors in the dataset. It only requires the metric type (metric_type) and top-k (limit) as index building and search parameters.

For GPU_BRUTE_FORCE, no addition index building parameters or search parameters are required.

![image](https://github.com/user-attachments/assets/7f719343-189a-4f03-ad00-7af179a74f75)
