### PR TITLE
fix: prevent the frontend from crashing on invalid indexes in results

### DIFF
--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -259,9 +259,7 @@ class TestResult(BaseModel):
                 try:
                     task_config["db_case_config"] = db.case_config_cls(index_type=index_value)(**raw_case_cfg)
                 except Exception:
-                    log.exception(
-                        f"Couldn't get class for index '{index_value}' ({full_path})"
-                    )
+                    log.exception(f"Couldn't get class for index '{index_value}' ({full_path})")
                     task_config["db_case_config"] = EmptyDBCaseConfig(**raw_case_cfg)
 
                 case_result["task_config"] = task_config
@@ -366,4 +364,3 @@ class TestResult(BaseModel):
         tmp_logger = logging.getLogger("no_color")
         for f in fmt:
             tmp_logger.info(f)
-

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -6,8 +6,6 @@ from typing import Self
 
 import ujson
 
-from vectordb_bench.backend.clients.api import EmptyDBCaseConfig
-
 from . import config
 from .backend.cases import CaseType
 from .backend.clients import (
@@ -260,8 +258,8 @@ class TestResult(BaseModel):
                 index_value = raw_case_cfg.get("index", None)
                 try:
                     task_config["db_case_config"] = db.case_config_cls(index_type=index_value)(**raw_case_cfg)
-                except:
-                    log.error(
+                except Exception:
+                    log.exception(
                         f"Couldn't get class for index '{index_value}' ({full_path})"
                     )
                     task_config["db_case_config"] = EmptyDBCaseConfig(**raw_case_cfg)
@@ -368,3 +366,4 @@ class TestResult(BaseModel):
         tmp_logger = logging.getLogger("no_color")
         for f in fmt:
             tmp_logger.info(f)
+


### PR DESCRIPTION
When the index type specified in a result can't be matched to the config classes of a given database, it currently crashes to frontend because of the attempt to make a call on a `NoneType`.

This makes it so that the empty config is used in such cases but also prints an error to the console, so that people can ideally fix the problematic index config.

Fixes #512
