### PR TITLE
Add qdrant CLI support and fix support for optional fields

### DIFF
--- a/vectordb_bench/backend/clients/qdrant_cloud/cli.py
+++ b/vectordb_bench/backend/clients/qdrant_cloud/cli.py
@@ -1,0 +1,43 @@
+from typing import Annotated, Unpack
+
+import click
+from pydantic import SecretStr
+
+from ....cli.cli import (
+    CommonTypedDict,
+    cli,
+    click_parameter_decorators_from_typed_dict,
+    run,
+)
+from .. import DB
+
+
+class QdrantTypedDict(CommonTypedDict):
+    url: Annotated[
+        str,
+        click.option("--url", type=str, help="URL connection string", required=True),
+    ]
+    api_key: Annotated[
+        str | None,
+        click.option("--api-key", type=str, help="API key for authentication", required=False),
+    ]
+
+
+@cli.command()
+@click_parameter_decorators_from_typed_dict(QdrantTypedDict)
+def QdrantCloud(**parameters: Unpack[QdrantTypedDict]):
+    from .config import QdrantConfig, QdrantIndexConfig
+
+    config_params = {
+        "db_label": parameters["db_label"],
+        "url": SecretStr(parameters["url"]),
+    }
+
+    config_params["api_key"] = SecretStr(parameters["api_key"]) if parameters["api_key"] else None
+
+    run(
+        db=DB.QdrantCloud,
+        db_config=QdrantConfig(**config_params),
+        db_case_config=QdrantIndexConfig(),
+        **parameters,
+    )

--- a/vectordb_bench/backend/clients/qdrant_cloud/config.py
+++ b/vectordb_bench/backend/clients/qdrant_cloud/config.py
@@ -6,14 +6,14 @@ from ..api import DBCaseConfig, DBConfig, MetricType
 # Allowing `api_key` to be left empty, to ensure compatibility with the open-source Qdrant.
 class QdrantConfig(DBConfig):
     url: SecretStr
-    api_key: SecretStr
+    api_key: SecretStr | None = None
 
     def to_dict(self) -> dict:
-        api_key = self.api_key.get_secret_value()
-        if len(api_key) > 0:
+        api_key_value = self.api_key.get_secret_value() if self.api_key else None
+        if api_key_value:
             return {
                 "url": self.url.get_secret_value(),
-                "api_key": self.api_key.get_secret_value(),
+                "api_key": api_key_value,
                 "prefer_grpc": True,
             }
         return {

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -9,6 +9,7 @@ from ..backend.clients.pgdiskann.cli import PgDiskAnn
 from ..backend.clients.pgvecto_rs.cli import PgVectoRSHNSW, PgVectoRSIVFFlat
 from ..backend.clients.pgvector.cli import PgVectorHNSW
 from ..backend.clients.pgvectorscale.cli import PgVectorScaleDiskAnn
+from ..backend.clients.qdrant_cloud.cli import QdrantCloud
 from ..backend.clients.redis.cli import Redis
 from ..backend.clients.test.cli import Test
 from ..backend.clients.tidb.cli import TiDB
@@ -35,6 +36,7 @@ cli.add_command(TiDB)
 cli.add_command(Clickhouse)
 cli.add_command(Vespa)
 cli.add_command(LanceDB)
+cli.add_command(QdrantCloud)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While working on CLI support using qdrant's docker image, I came across the problem that the current implementation to support empty strings actually doesn't seem to work. Using an empty string resulted in the following error:

```
  File "C:\Users\andy\temp\VectorDBBench\vectordb_bench\backend\clients\qdrant_cloud\cli.py", line 39, in QdrantCloud
    db_config=QdrantConfig(**config_params),
              ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "pydantic\\main.py", line 347, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for QdrantConfig
api_key
  none is not an allowed value (type=type_error.none.not_allowed)
```

I guess pydantic interprets empty strings as None?
To resolve this, I made this field actually optional (instead of relying on empty string) and added handling for optional fields to the frontend.

If you like these changes, what do you think about renaming things to just "qdrant" (no "cloud") and making `http://localhost:6333` the default value for `url`?