### PR TITLE
Fixing bugs in aws opensearch client and added fp16 support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,12 @@ Options:
   --force-merge-enabled BOOLEAN   Whether to perform force merge operation
   --flush-threshold-size TEXT     Size threshold for flushing the transaction
                                   log
+  --engine TEXT                   type of engine to use valid values [faiss, lucene]
   # Memory Management
   --cb-threshold TEXT             k-NN Memory circuit breaker threshold
-
+  
+  # Quantization Type
+  --quantization-type TEXT        which type of quantization to use valid values [fp32, fp16]
   --help                          Show this message and exit.
   ```
 

--- a/vectordb_bench/backend/clients/aws_opensearch/cli.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/cli.py
@@ -48,16 +48,6 @@ class AWSOpenSearchTypedDict(TypedDict):
         ),
     ]
 
-    number_of_indexing_clients: Annotated[
-        int,
-        click.option(
-            "--number-of-indexing-clients",
-            type=int,
-            help="Number of concurrent indexing clients",
-            default=1,
-        ),
-    ]
-
     number_of_segments: Annotated[
         int,
         click.option("--number-of-segments", type=int, help="Target number of segments after merging", default=1),
@@ -117,9 +107,12 @@ def AWSOpenSearch(**parameters: Unpack[AWSOpenSearchHNSWTypedDict]):
             refresh_interval=parameters["refresh_interval"],
             force_merge_enabled=parameters["force_merge_enabled"],
             flush_threshold_size=parameters["flush_threshold_size"],
-            number_of_indexing_clients=parameters["number_of_indexing_clients"],
             index_thread_qty_during_force_merge=parameters["index_thread_qty_during_force_merge"],
             cb_threshold=parameters["cb_threshold"],
+            efConstruction=parameters["ef_construction"],
+            efSearch=parameters["ef_runtime"],
+            M=parameters["m"],
+
         ),
         **parameters,
     )

--- a/vectordb_bench/backend/clients/aws_opensearch/cli.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/cli.py
@@ -11,12 +11,13 @@ from ....cli.cli import (
     run,
 )
 from .. import DB
+from .config import AWSOS_Engine, AWSOSQuantization
 
 
 class AWSOpenSearchTypedDict(TypedDict):
     host: Annotated[str, click.option("--host", type=str, help="Db host", required=True)]
-    port: Annotated[int, click.option("--port", type=int, default=443, help="Db Port")]
-    user: Annotated[str, click.option("--user", type=str, default="admin", help="Db User")]
+    port: Annotated[int, click.option("--port", type=int, default=80, help="Db Port")]
+    user: Annotated[str, click.option("--user", type=str, help="Db User")]
     password: Annotated[str, click.option("--password", type=str, help="Db password")]
     number_of_shards: Annotated[
         int,
@@ -82,6 +83,28 @@ class AWSOpenSearchTypedDict(TypedDict):
         ),
     ]
 
+    quantization_type: Annotated[
+        str | None,
+        click.option(
+            "--quantization-type",
+            type=click.Choice(["fp32", "fp16"]),
+            help="quantization type for vectors (in index)",
+            default="fp32",
+            required=False,
+        ),
+    ]
+
+    engine: Annotated[
+        str | None,
+        click.option(
+            "--engine",
+            type=click.Choice(["faiss", "lucene"]),
+            help="quantization type for vectors (in index)",
+            default="faiss",
+            required=False,
+        ),
+    ]
+
 
 class AWSOpenSearchHNSWTypedDict(CommonTypedDict, AWSOpenSearchTypedDict, HNSWFlavor2): ...
 
@@ -112,7 +135,8 @@ def AWSOpenSearch(**parameters: Unpack[AWSOpenSearchHNSWTypedDict]):
             efConstruction=parameters["ef_construction"],
             efSearch=parameters["ef_runtime"],
             M=parameters["m"],
-
+            engine=AWSOS_Engine(parameters["engine"]),
+            quantization_type=AWSOSQuantization(parameters["quantization_type"]),
         ),
         **parameters,
     )

--- a/vectordb_bench/backend/clients/aws_opensearch/config.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/config.py
@@ -28,7 +28,6 @@ class AWSOpenSearchConfig(DBConfig, BaseModel):
 
 
 class AWSOS_Engine(Enum):
-    nmslib = "nmslib"
     faiss = "faiss"
     lucene = "Lucene"
 
@@ -46,7 +45,6 @@ class AWSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
     refresh_interval: str | None = "60s"
     force_merge_enabled: bool | None = True
     flush_threshold_size: str | None = "5120mb"
-    number_of_indexing_clients: int | None = 1
     index_thread_qty_during_force_merge: int
     cb_threshold: str | None = "50%"
 
@@ -54,11 +52,6 @@ class AWSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
         if self.metric_type == MetricType.IP:
             return "innerproduct"
         if self.metric_type == MetricType.COSINE:
-            if self.engine == AWSOS_Engine.faiss:
-                log.info(
-                    "Using innerproduct because faiss doesn't support cosine as metric type for Opensearch",
-                )
-                return "innerproduct"
             return "cosinesimil"
         return "l2"
 


### PR DESCRIPTION
Fixing bugs in aws opensearch client and added fp16 support

Testing using

```
vectordbbench awsopensearch --db-label 10m-run --task-label ef-search-40 --m 16 --ef-construction 200 --ef-runtime 100 --host <HOST-Name> --port 443 --user admin --password '<MYpass>' --case-type Performance768D10M --number-of-shards 1  --number-of-replicas 0   --num-concurrency 10,30,40,150,200 --k 10 --quantization-type fp16

```