### PR TITLE
Fix python import in MemoryDB client

### DIFF
--- a/vectordb_bench/backend/clients/memorydb/memorydb.py
+++ b/vectordb_bench/backend/clients/memorydb/memorydb.py
@@ -9,10 +9,10 @@ import redis
 from redis import Redis
 from redis.cluster import RedisCluster
 from redis.commands.search.field import NumericField, TagField, VectorField
-from redis.commands.search.indexDefinition import IndexDefinition
+from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
-from ..api import IndexType, VectorDB
+from ..api import VectorDB
 from .config import MemoryDBIndexConfig
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### Summary

A recent refactoring commit https://github.com/zilliztech/VectorDBBench/commit/032515f9f066398a8fc6c31c0e8c33ed43a0f446 reordered the import statements, which resulted that the enum `IndexType` is now imported from the wrong package. This causes a runtime failure when executing VectorDBBench for MemoryDB client, because `HASH` is not defined on relative import of [IndexType](https://github.com/zilliztech/VectorDBBench/blob/main/vectordb_bench/backend/clients/api.py#L17).

### Details

This was caused because the class was mistakenly imported from both packages before the refactor. https://github.com/zilliztech/VectorDBBench/commit/032515f9f066398a8fc6c31c0e8c33ed43a0f446#diff-1638e273a6d7eee7b4412bf79bda9112da86d53e18d1b650b8b80a2e1df4f7e6R15

Before refactoring, `IndexType` is effectively imported from redis
```
from ..api import VectorDB, DBCaseConfig, IndexType
...
from redis.commands.search.field import TagField, VectorField, NumericField
from redis.commands.search.indexDefinition import IndexDefinition, IndexType
```

After refactoring, `IndexType` is effectively imported from relative import
```
from redis.commands.search.field import NumericField, TagField, VectorField
from redis.commands.search.indexDefinition import IndexDefinition
...
from ..api import IndexType, VectorDB
```