### PR TITLE
change lancedb vector type to float32

### DIFF
--- a/vectordb_bench/backend/clients/lancedb/lancedb.py
+++ b/vectordb_bench/backend/clients/lancedb/lancedb.py
@@ -45,7 +45,7 @@ class LanceDB(VectorDB):
             db.open_table(self.table_name)
         except Exception:
             schema = pa.schema(
-                [pa.field("id", pa.int64()), pa.field("vector", pa.list_(pa.float64(), list_size=self.dim))]
+                [pa.field("id", pa.int64()), pa.field("vector", pa.list_(pa.float32(), list_size=self.dim))]
             )
             db.create_table(self.table_name, schema=schema, mode="overwrite")
 


### PR DESCRIPTION
In the original implementation, the vector type used in LanceDB is float64. However, it seems that HNSW-SQ does not work with float64, and the LanceDB document also uses float32: https://lancedb.github.io/lancedb/guides/tables/#from-list-of-tuples-or-dictionaries.
The current version has been tested with Performance768D1M and the benchmark finished successfully.

So I modified the vector type to float32, I think using float32 is also a fair choice since databases such as Qdrant and Weavite.

The error with float64 is attached below:

```
2025-06-09 04:17:34,593 | INFO: Task:
TaskConfig(db=<DB.LanceDB: 'LanceDB'>, db_config=LanceDBConfig(db_label='2025-06-09T04:17:34.546886', version='', note='', uri='/mnt/sdb/zebin/2025-vectordb-bench-all/lancedb-cohere-1m-hnsw-main', token=None), db_case_config=LanceDBHNSWIndexConfig(index=<IndexType.HNSW: 'HNSW'>, metric_type=<MetricType.L2: 'L2'>, num_partitions=0, num_sub_vectors=0, nbits=8, sample_rate=256, max_iterations=50, m=0, ef_construction=0), case_config=CaseConfig(case_id=<CaseType.Performance768D1M: 5>, custom_case={}, k=10, concurrency_search_config=ConcurrencySearchConfig(num_concurrency=[1], concurrency_duration=30, concurrency_timeout=3600)), stages=['drop_old', 'load', 'search_serial', 'search_concurrent'])
 (cli.py:516) (3553105)
2025-06-09 04:17:34,593 | INFO: generated uuid for the tasks: 97893cb8586d427199e63c60cad84c14 (interface.py:72) (3553105)
2025-06-09 04:17:34,714 | INFO | DB             | CaseType     Dataset               Filter | task_label (task_runner.py:340)
2025-06-09 04:17:34,714 | INFO | -----------    | ------------ -------------------- ------- | -------    (task_runner.py:340)
2025-06-09 04:17:34,714 | INFO | LanceDB-2025-06-09T04:17:34.546886 | Performance  Cohere-MEDIUM-1M        None | 97893cb8586d427199e63c60cad84c14 (task_runner.py:340)
2025-06-09 04:17:34,714 | INFO: task submitted: id=97893cb8586d427199e63c60cad84c14, 97893cb8586d427199e63c60cad84c14, case number: 1 (interface.py:242) (3553105)
2025-06-09 04:17:35,503 | INFO: [1/1] start case: {'label': <CaseLabel.Performance: 2>, 'dataset': {'data': {'name': 'Cohere', 'size': 1000000, 'dim': 768, 'metric_type': <MetricType.COSINE: 'COSINE'>}}, 'db': 'LanceDB-2025-06-09T04:17:34.546886'}, drop_old=True (interface.py:172) (3553150)
2025-06-09 04:17:35,503 | INFO: Starting run (task_runner.py:105) (3553150)
2025-06-09 04:17:35,640 | WARNING: Failed to drop table vector_bench_test: Table 'vector_bench_test' was not found (lancedb.py:42) (3553150)
[2025-06-09T02:17:35Z WARN  lance::dataset::write::insert] No existing dataset at /mnt/sdb/zebin/2025-vectordb-bench-all/lancedb-cohere-1m-hnsw-main/vector_bench_test.lance, it will be created
2025-06-09 04:17:36,833 | INFO: Read the entire file into memory: test.parquet (dataset.py:251) (3553150)
2025-06-09 04:17:36,879 | INFO: Read the entire file into memory: neighbors.parquet (dataset.py:251) (3553150)
2025-06-09 04:17:36,930 | INFO: Start performance case (task_runner.py:147) (3553150)
2025-06-09 04:17:37,886 | INFO: (SpawnProcess-1:1) Start inserting embeddings in batch 100 (serial_runner.py:43) (3553331)
2025-06-09 04:17:37,887 | INFO: Get iterator for shuffle_train.parquet (dataset.py:272) (3553331)
2025-06-09 04:18:05,632 | INFO: (SpawnProcess-1:1) Loaded 100000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 04:20:02,058 | INFO: (SpawnProcess-1:1) Loaded 200000 embeddings into VectorDB (serial_runner.py:67) (3553331)
^[[D2025-06-09 04:24:54,065 | INFO: (SpawnProcess-1:1) Loaded 300000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 04:34:01,485 | INFO: (SpawnProcess-1:1) Loaded 400000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 04:48:50,951 | INFO: (SpawnProcess-1:1) Loaded 500000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 05:10:42,194 | INFO: (SpawnProcess-1:1) Loaded 600000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 05:41:02,098 | INFO: (SpawnProcess-1:1) Loaded 700000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 06:21:25,720 | INFO: (SpawnProcess-1:1) Loaded 800000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 07:13:25,226 | INFO: (SpawnProcess-1:1) Loaded 900000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 08:18:44,377 | INFO: (SpawnProcess-1:1) Loaded 1000000 embeddings into VectorDB (serial_runner.py:67) (3553331)
2025-06-09 08:18:44,473 | INFO: (SpawnProcess-1:1) Finish loading all dataset into VectorDB, dur=14466.586044576019 (serial_runner.py:69) (3553331)
2025-06-09 08:18:45,713 | INFO: Creating index for LanceDB table (vector_bench_test) (lancedb.py:93) (3572375)
2025-06-09 08:22:40,243 | INFO: Finish loading the entire dataset into VectorDB, insert_duration=14467.800307106227, optimize_duration=234.1213205307722 load_duration(insert + optimize) = 14701.9216 (task_runner.py:155) (3553150)
2025-06-09 08:22:41,151 | INFO: Start search 30s in concurrency 1, filters: None (mp_runner.py:118) (3553150)
2025-06-09 08:22:42,180 | INFO: Syncing all process and start concurrency search, concurrency=1 (mp_runner.py:125) (3553150)

thread 'lance-cpu' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lance-index-0.29.0/src/vector/sq/storage.rs:394:17:
Unsupported data type for ScalarQuantizationStorage
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'tokio-runtime-worker' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lance-core-0.29.0/src/utils/tokio.rs:66:24:
called `Result::unwrap()` on an `Err` value: RecvError(())
2025-06-09 08:22:46,152 | WARNING: VectorDB search_embedding error: rust future panicked: unknown error (mp_runner.py:75) (3572889)
Traceback (most recent call last):
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 69, in search
    self.db.search_embedding(
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/clients/lancedb/lancedb.py", line 88, in search_embedding
    results = self.table.search(query).select(["id"]).limit(k).to_list()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/query.py", line 740, in to_list
    return self.to_arrow(timeout=timeout).to_pylist()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/query.py", line 1209, in to_arrow
    return self.to_batches(timeout=timeout).read_all()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/query.py", line 1265, in to_batches
    result_set = self._table._execute_query(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/table.py", line 2531, in _execute_query
    async_iter = LOOP.run(
                 ^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/background_loop.py", line 25, in run
    return asyncio.run_coroutine_threadsafe(future, self.loop).result()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/table.py", line 3674, in _execute_query
    return await async_query.to_batches(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/query.py", line 2847, in to_batches
    results = pa.Table.from_batches(await reader.read_all(), reader.schema)
                                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/arrow.py", line 48, in read_all
    return [batch async for batch in self]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/arrow.py", line 48, in <listcomp>
    return [batch async for batch in self]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/site-packages/lancedb/arrow.py", line 54, in __anext__
    return await self._inner.__anext__()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pyo3_async_runtimes.RustPanic: rust future panicked: unknown error
2025-06-09 08:22:47,871 | WARNING: Fail to search, concurrencies: [1], max_qps before failure=0, reason=Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed (mp_runner.py:145) (3553150)
concurrent.futures.process._RemoteTraceback: 
"""
pyo3_async_runtimes.RustPanic: rust future panicked: unknown error

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/process.py", line 217, in _sendback_result
    result_queue.put(_ResultItem(work_id, result=result,
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/multiprocessing/queues.py", line 371, in put
    obj = _ForkingPickler.dumps(obj)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
_pickle.PicklingError: Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 128, in _run_all_concurrencies_mem_efficient
    all_count = sum([r.result()[0] for r in future_iter])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 128, in <listcomp>
    all_count = sum([r.result()[0] for r in future_iter])
                     ^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
_pickle.PicklingError: Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed
2025-06-09 08:22:47,872 | WARNING: search error: Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed, Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed (task_runner.py:231) (3553150)
2025-06-09 08:22:47,873 | WARNING: Failed to run performance case, reason = Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed (task_runner.py:182) (3553150)
Traceback (most recent call last):
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 165, in _run_perf_case
    search_results = self._conc_search()
                     ^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 232, in _conc_search
    raise e from None
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 229, in _conc_search
    return self.search_runner.run()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 179, in run
    return self._run_all_concurrencies_mem_efficient()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 152, in _run_all_concurrencies_mem_efficient
    raise e from None
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 128, in _run_all_concurrencies_mem_efficient
    all_count = sum([r.result()[0] for r in future_iter])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 128, in <listcomp>
    all_count = sum([r.result()[0] for r in future_iter])
                     ^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
_pickle.PicklingError: Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed
2025-06-09 08:22:47,874 | WARNING: [1/1] case {'label': <CaseLabel.Performance: 2>, 'dataset': {'data': {'name': 'Cohere', 'size': 1000000, 'dim': 768, 'metric_type': <MetricType.COSINE: 'COSINE'>}}, 'db': 'LanceDB-2025-06-09T04:17:34.546886'} failed to run, reason=Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed (interface.py:194) (3553150)
Traceback (most recent call last):
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/interface.py", line 173, in _async_task_v2
    case_res.metrics = runner.run(drop_old)
                       ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 112, in run
    return self._run_perf_case(drop_old)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 184, in _run_perf_case
    raise e from None
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 165, in _run_perf_case
    search_results = self._conc_search()
                     ^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 232, in _conc_search
    raise e from None
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/task_runner.py", line 229, in _conc_search
    return self.search_runner.run()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 179, in run
    return self._run_all_concurrencies_mem_efficient()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 152, in _run_all_concurrencies_mem_efficient
    raise e from None
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 128, in _run_all_concurrencies_mem_efficient
    all_count = sum([r.result()[0] for r in future_iter])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/backend/runner/mp_runner.py", line 128, in <listcomp>
    all_count = sum([r.result()[0] for r in future_iter])
                     ^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/zebin/anaconda3/envs/vectordb-bench-main/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
_pickle.PicklingError: Can't pickle <class 'pyo3_async_runtimes.RustPanic'>: import of module 'pyo3_async_runtimes' failed
2025-06-09 08:22:47,875 | INFO |Task summary: run_id=97893, task_label=97893cb8586d427199e63c60cad84c14 (models.py:375)
2025-06-09 08:22:47,875 | INFO |DB      | db_label                      case              label                            | load_dur    qps        latency(p99)    recall        max_load_count | label (models.py:375)
2025-06-09 08:22:47,875 | INFO |------- | ----------------------------- ----------------- -------------------------------- | ----------- ---------- --------------- ------------- -------------- | ----- (models.py:375)
2025-06-09 08:22:47,875 | INFO |LanceDB | 2025-06-09T04:17:34.546886    Performance768D1M 97893cb8586d427199e63c60cad84c14 | 0.0         0.0        0.0             0.0           0              | x     (models.py:375)
2025-06-09 08:22:47,876 | INFO: write results to disk /mnt/sdb/zebin/2025-vectordb-bench-all/VectorDBBench-main/vectordb_bench/results/LanceDB/result_20250609_97893cb8586d427199e63c60cad84c14_lancedb.json (models.py:243) (3553150)
2025-06-09 08:22:47,876 | INFO: Success to finish task: label=97893cb8586d427199e63c60cad84c14, run_id=97893cb8586d427199e63c60cad84c14 (interface.py:213) (3553150)
```