### PR TITLE
expose lancedb index parameters to the cli interface

### DIFF
--- a/vectordb_bench/backend/clients/lancedb/cli.py
+++ b/vectordb_bench/backend/clients/lancedb/cli.py
@@ -59,11 +59,39 @@ def LanceDBAutoIndex(**parameters: Unpack[LanceDBTypedDict]):
 
 
 class LanceDBIVFPQTypedDict(CommonTypedDict, LanceDBTypedDict):
-    num_partitions: Annotated[int, click.option("--num-partitions", type=int, default=0, help="Number of partitions for IVFPQ index, unset = use LanceDB default")]
-    num_sub_vectors: Annotated[int, click.option("--num-sub-vectors", type=int, default=0, help="Number of sub-vectors for IVFPQ index, unset = use LanceDB default")]
-    nbits: Annotated[int, click.option("--nbits", type=int, default=8, help="Number of bits for IVFPQ index (must be 4 or 8), unset = use LanceDB default")]
-    nprobes: Annotated[int, click.option("--nprobes", type=int, default=0, help="Number of probes for IVFPQ search, unset = use LanceDB default")]
-    
+    num_partitions: Annotated[
+        int,
+        click.option(
+            "--num-partitions",
+            type=int,
+            default=0,
+            help="Number of partitions for IVFPQ index, unset = use LanceDB default",
+        ),
+    ]
+    num_sub_vectors: Annotated[
+        int,
+        click.option(
+            "--num-sub-vectors",
+            type=int,
+            default=0,
+            help="Number of sub-vectors for IVFPQ index, unset = use LanceDB default",
+        ),
+    ]
+    nbits: Annotated[
+        int,
+        click.option(
+            "--nbits",
+            type=int,
+            default=8,
+            help="Number of bits for IVFPQ index (must be 4 or 8), unset = use LanceDB default",
+        ),
+    ]
+    nprobes: Annotated[
+        int,
+        click.option(
+            "--nprobes", type=int, default=0, help="Number of probes for IVFPQ search, unset = use LanceDB default"
+        ),
+    ]
 
 
 @cli.command()
@@ -78,21 +106,22 @@ def LanceDBIVFPQ(**parameters: Unpack[LanceDBIVFPQTypedDict]):
             uri=parameters["uri"],
             token=SecretStr(parameters["token"]) if parameters.get("token") else None,
         ),
-        # db_case_config=_lancedb_case_config.get(IndexType.IVFPQ)(),
         db_case_config=LanceDBIndexConfig(
             index=IndexType.IVFPQ,
             num_partitions=parameters["num_partitions"],
             num_sub_vectors=parameters["num_sub_vectors"],
             nbits=parameters["nbits"],
             nprobes=parameters["nprobes"],
-        ),  
+        ),
         **parameters,
     )
 
 
 class LanceDBHNSWTypedDict(CommonTypedDict, LanceDBTypedDict):
     m: Annotated[int, click.option("--m", type=int, default=0, help="HNSW parameter m")]
-    ef_construction: Annotated[int, click.option("--ef-construction", type=int, default=0, help="HNSW parameter ef_construction")]
+    ef_construction: Annotated[
+        int, click.option("--ef-construction", type=int, default=0, help="HNSW parameter ef_construction")
+    ]
     ef: Annotated[int, click.option("--ef", type=int, default=0, help="HNSW search parameter ef")]
 
 

--- a/vectordb_bench/backend/clients/lancedb/config.py
+++ b/vectordb_bench/backend/clients/lancedb/config.py
@@ -56,7 +56,7 @@ class LanceDBIndexConfig(BaseModel, DBCaseConfig):
         params = {}
         if self.nprobes > 0:
             params["nprobes"] = self.nprobes
-        
+
         return params
 
     def parse_metric(self) -> str:
@@ -99,11 +99,12 @@ class LanceDBHNSWIndexConfig(LanceDBIndexConfig):
             params["ef_construction"] = self.ef_construction
 
         return params
+
     def search_param(self) -> dict:
         params = {}
         if self.ef != 0:
             params = {"ef": self.ef}
-        
+
         return params
 
 

--- a/vectordb_bench/backend/clients/lancedb/lancedb.py
+++ b/vectordb_bench/backend/clients/lancedb/lancedb.py
@@ -34,7 +34,7 @@ class LanceDB(VectorDB):
         self.uri = db_config["uri"]
         # avoid the search_param being called every time during the search process
         self.search_config = db_case_config.search_param()
-        
+
         log.info(f"Search config: {self.search_config}")
 
         db = lancedb.connect(self.uri)
@@ -81,27 +81,22 @@ class LanceDB(VectorDB):
         filters: dict | None = None,
     ) -> list[int]:
         if filters:
-            results = (
-                self.table.search(query)
-                .select(["id"])
-                .where(f"id >= {filters['id']}", prefilter=True)
-                .limit(k)
-            )
-            if self.case_config.index == IndexType.IVFPQ and 'nprobes' in self.search_config.keys():
+            results = self.table.search(query).select(["id"]).where(f"id >= {filters['id']}", prefilter=True).limit(k)
+            if self.case_config.index == IndexType.IVFPQ and "nprobes" in self.search_config:
                 results = results.nprobes(self.search_config["nprobes"]).to_list()
-            elif self.case_config.index == IndexType.HNSW and 'ef' in self.search_config.keys():
-                results = results.ef(self.search_config['ef']).to_list()
+            elif self.case_config.index == IndexType.HNSW and "ef" in self.search_config:
+                results = results.ef(self.search_config["ef"]).to_list()
             else:
                 results = results.to_list()
         else:
             results = self.table.search(query).select(["id"]).limit(k)
-            if self.case_config.index == IndexType.IVFPQ and 'nprobes' in self.search_config.keys():
+            if self.case_config.index == IndexType.IVFPQ and "nprobes" in self.search_config:
                 results = results.nprobes(self.search_config["nprobes"]).to_list()
-            elif self.case_config.index == IndexType.HNSW and 'ef' in self.search_config.keys():
-                results = results.ef(self.search_config['ef']).to_list()
+            elif self.case_config.index == IndexType.HNSW and "ef" in self.search_config:
+                results = results.ef(self.search_config["ef"]).to_list()
             else:
                 results = results.to_list()
-    
+
         return [int(result["id"]) for result in results]
 
     def optimize(self, data_size: int | None = None):


### PR DESCRIPTION
Expose the lancedb index parameters to the cli interface. Omitting these parameters will set the same value as the previous version, so this pull request will not change the behavior of existing scripts. Following is a list of the parameters that can be set with the cli interface:

lancedbivfpq
- num-partitions
- num-sub-vectors
- nbits
- nprobes

lancedbhnsw
- m
- ef-construct
- ef


