### PR TITLE
add num_shards to MilvusConfig.to_dict()

### DIFF
--- a/vectordb_bench/backend/clients/milvus/config.py
+++ b/vectordb_bench/backend/clients/milvus/config.py
@@ -14,6 +14,7 @@ class MilvusConfig(DBConfig):
             "uri": self.uri.get_secret_value(),
             "user": self.user if self.user else None,
             "password": self.password.get_secret_value() if self.password else None,
+            "num_shards": self.num_shards,
         }
 
     @validator("*")


### PR DESCRIPTION
In #526 an argument num_shards is added to milvus, however, this argument is not included in the to_dict() function of MilvusConfig, leading to an error at line https://github.com/zilliztech/VectorDBBench/blob/d6dc089fbefb35e75fbffcc82d43dd6f2a299b8d/vectordb_bench/backend/clients/milvus/milvus.py#L67.

