### PR TITLE
Fix back to results page error

### DIFF
--- a/vectordb_bench/frontend/components/check_results/nav.py
+++ b/vectordb_bench/frontend/components/check_results/nav.py
@@ -19,7 +19,7 @@ def NavToQuriesPerDollar(st):
 def NavToResults(st, key="nav-to-results"):
     navClick = st.button("< &nbsp;&nbsp;Back to Results", key=key)
     if navClick:
-        switch_page("vdb benchmark")
+        switch_page("results")
 
 
 def NavToPages(st):


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/2c5c2c2e-1d2d-4e1f-b48d-1de0c6e71aa2)


```
  File "/Users/zilliz/workspace/VectorDBBench/.venv/lib/python3.12/site-packages/streamlit_extras/switch_page_button/__init__.py", line 41, in switch_page
    raise ValueError(f"Could not find page {page_name}. Must be one of {page_names}")
ValueError: Could not find page vdb benchmark. Must be one of ['vdbbench', 'concurrent', 'custom', 'label filter', 'quries per dollar', 'results', 'run test', 'streaming', 'tables']
```