### PR TITLE
Fix running `vectordbbench tidb` will return error

### DIFF
--- a/vectordb_bench/backend/clients/tidb/cli.py
+++ b/vectordb_bench/backend/clients/tidb/cli.py
@@ -17,7 +17,6 @@ class TiDBTypedDict(CommonTypedDict):
             help="Username",
             default="root",
             show_default=True,
-            required=True,
         ),
     ]
     password: Annotated[
@@ -37,7 +36,6 @@ class TiDBTypedDict(CommonTypedDict):
             type=str,
             default="127.0.0.1",
             show_default=True,
-            required=True,
             help="Db host",
         ),
     ]
@@ -48,7 +46,6 @@ class TiDBTypedDict(CommonTypedDict):
             type=int,
             default=4000,
             show_default=True,
-            required=True,
             help="Db Port",
         ),
     ]
@@ -59,7 +56,6 @@ class TiDBTypedDict(CommonTypedDict):
             type=str,
             default="test",
             show_default=True,
-            required=True,
             help="Db name",
         ),
     ]


### PR DESCRIPTION
## Problem description
running `vectordbbench tidb` will generate an error as follow, which is confusing.

```
(.venv) /DATA/disk1/VectorDBBench [fix_run_tidb]
>  vectordbbench tidb
Traceback (most recent call last):
  File "/DATA/disk1/VectorDBBench/.venv/bin/vectordbbench", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/DATA/disk1/VectorDBBench/.venv/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/DATA/disk1/VectorDBBench/.venv/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/DATA/disk1/VectorDBBench/.venv/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/DATA/disk1/VectorDBBench/.venv/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/DATA/disk1/VectorDBBench/.venv/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/DATA/disk1/VectorDBBench/vectordb_bench/backend/clients/tidb/cli.py", line 87, in TiDB
    db_config=TiDBConfig(
              ^^^^^^^^^^^
  File "pydantic/main.py", line 347, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for TiDBConfig
password
  Empty string! (type=value_error)
```

## What is changed and how it works
* Add a method for `TiDBConfig::not_empty_field` for ignoring the case that `password` is empty
* Remove `required` for some options for tidb because they have default value

After this fix, running `vectordbbench tidb` will try to connect to `127.0.0.1:4000`, which is the default port for tidb, and run the tests