### PR TITLE
fix: OSS OpenSearch insertion retry missing labels_data parameter

### DIFF
--- a/vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py
+++ b/vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py
@@ -171,7 +171,7 @@ class OSSOpenSearch(VectorDB):
         except Exception as e:
             log.warning(f"Failed to insert data: {self.index_name} error: {e!s}")
             time.sleep(10)
-            return self._insert_with_single_client(embeddings, metadata)
+            return self._insert_with_single_client(embeddings, metadata, labels_data)
 
     def _insert_with_multiple_clients(
         self,
@@ -246,7 +246,7 @@ class OSSOpenSearch(VectorDB):
         if errors:
             log.warning("Some clients failed to insert data, retrying with single client")
             time.sleep(10)
-            return self._insert_with_single_client(embeddings, metadata)
+            return self._insert_with_single_client(embeddings, metadata, labels_data)
 
         resp = self.client.indices.stats(self.index_name)
         log.info(


### PR DESCRIPTION
## Problem
OSS OpenSearch streaming tests were crashing during data insertion when network issues or temporary failures occurred. The background benchmark process would terminate before search queries could start, causing test failures.

## Root Cause
Missing `labels_data` parameter in retry calls to `_insert_with_single_client()`. When insertion failed and the code attempted to retry, it caused a `TypeError: 'NoneType' object is not subscriptable` crash.

## Solution
Added missing `labels_data` parameter to two retry call locations:
- Single client insertion retry logic
- Multiple client fallback to single client logic

## Impact
- ✅ Streaming tests now recover gracefully from insertion failures
- ✅ Background processes continue running through network hiccups
- ✅ Search queries can start properly after insertion phases complete

## Testing
Fixes the EOFError and background process crashes observed in streaming performance tests with OSS OpenSearch.