### PR TITLE
optimize:milvus add replica-number parameter

### DIFF
--- a/vectordb_bench/backend/clients/milvus/cli.py
+++ b/vectordb_bench/backend/clients/milvus/cli.py
@@ -40,6 +40,17 @@ class MilvusTypedDict(TypedDict):
             show_default=True,
         ),
     ]
+    replica_number: Annotated[
+        int,
+        click.option(
+            "--replica-number",
+            type=int,
+            help="Number of replicas",
+            required=False,
+            default=1,
+            show_default=True,
+        ),
+    ]
 
 
 class MilvusAutoIndexTypedDict(CommonTypedDict, MilvusTypedDict): ...
@@ -58,6 +69,7 @@ def MilvusAutoIndex(**parameters: Unpack[MilvusAutoIndexTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=AutoIndexConfig(),
         **parameters,
@@ -77,6 +89,7 @@ def MilvusFlat(**parameters: Unpack[MilvusAutoIndexTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=FLATConfig(),
         **parameters,
@@ -99,6 +112,7 @@ def MilvusHNSW(**parameters: Unpack[MilvusHNSWTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=HNSWConfig(
             M=parameters["m"],
@@ -163,6 +177,7 @@ def MilvusHNSWPQ(**parameters: Unpack[MilvusHNSWPQTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=HNSWPQConfig(
             M=parameters["m"],
@@ -206,6 +221,7 @@ def MilvusHNSWPRQ(**parameters: Unpack[MilvusHNSWPRQTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=HNSWPRQConfig(
             M=parameters["m"],
@@ -246,6 +262,7 @@ def MilvusHNSWSQ(**parameters: Unpack[MilvusHNSWSQTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=HNSWSQConfig(
             M=parameters["m"],
@@ -276,6 +293,7 @@ def MilvusIVFFlat(**parameters: Unpack[MilvusIVFFlatTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=IVFFlatConfig(
             nlist=parameters["nlist"],
@@ -298,6 +316,7 @@ def MilvusIVFSQ8(**parameters: Unpack[MilvusIVFFlatTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=IVFSQ8Config(
             nlist=parameters["nlist"],
@@ -359,6 +378,7 @@ def MilvusIVFRabitQ(**parameters: Unpack[MilvusIVFRABITQTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=IVFRABITQConfig(
             nlist=parameters["nlist"],
@@ -389,6 +409,7 @@ def MilvusDISKANN(**parameters: Unpack[MilvusDISKANNTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=DISKANNConfig(
             search_list=parameters["search_list"],
@@ -418,6 +439,7 @@ def MilvusGPUIVFFlat(**parameters: Unpack[MilvusGPUIVFTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=GPUIVFFlatConfig(
             nlist=parameters["nlist"],
@@ -453,6 +475,7 @@ def MilvusGPUBruteForce(**parameters: Unpack[MilvusGPUBruteForceTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=GPUBruteForceConfig(
             metric_type=parameters["metric_type"],
@@ -485,6 +508,7 @@ def MilvusGPUIVFPQ(**parameters: Unpack[MilvusGPUIVFPQTypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=GPUIVFPQConfig(
             nlist=parameters["nlist"],
@@ -525,6 +549,7 @@ def MilvusGPUCAGRA(**parameters: Unpack[MilvusGPUCAGRATypedDict]):
             user=parameters["user_name"],
             password=SecretStr(parameters["password"]) if parameters["password"] else None,
             num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
         ),
         db_case_config=GPUCAGRAConfig(
             intermediate_graph_degree=parameters["intermediate_graph_degree"],

--- a/vectordb_bench/backend/clients/milvus/config.py
+++ b/vectordb_bench/backend/clients/milvus/config.py
@@ -8,6 +8,7 @@ class MilvusConfig(DBConfig):
     user: str | None = None
     password: SecretStr | None = None
     num_shards: int = 1
+    replica_number: int = 1
 
     def to_dict(self) -> dict:
         return {
@@ -15,6 +16,7 @@ class MilvusConfig(DBConfig):
             "user": self.user if self.user else None,
             "password": self.password.get_secret_value() if self.password else None,
             "num_shards": self.num_shards,
+            "replica_number": self.replica_number,
         }
 
     @validator("*")

--- a/vectordb_bench/backend/clients/milvus/milvus.py
+++ b/vectordb_bench/backend/clients/milvus/milvus.py
@@ -92,7 +92,7 @@ class Milvus(VectorDB):
             )
 
             self.create_index()
-            col.load()
+            col.load(replica_number=self.db_config.get("replica_number", 1))
 
         connections.disconnect("default")
 


### PR DESCRIPTION
Fixes #587

- 当前 milvus 不支持透传replica_number参数，支持传replica_number参数，默认值为1，非执行时必填。

### 验证方式
1. vectordbbench milvusxx --help，参数中包含replica_number；
2. 分别创建两个配置文件，一个不配置replica_number参数，一个配置；
3. 框架执行测试，测试结果符合预期，配置生效；