### PR TITLE
bugfix: remove metric_type from GPUBruteForceConfig

### DIFF
--- a/vectordb_bench/backend/clients/milvus/config.py
+++ b/vectordb_bench/backend/clients/milvus/config.py
@@ -320,7 +320,6 @@ class GPUIVFFlatConfig(MilvusIndexConfig, DBCaseConfig):
 
 class GPUBruteForceConfig(MilvusIndexConfig, DBCaseConfig):
     limit: int = 10  # Default top-k for search
-    metric_type: str  # Metric type (e.g., 'L2', 'IP', etc.)
     index: IndexType = IndexType.GPU_BRUTE_FORCE  # Index type set to GPU_BRUTE_FORCE
 
     def index_param(self) -> dict:


### PR DESCRIPTION
When I choose GPU_BRUTE_FORCE, it returns an error.
I guess this is due to overriding existing variable 'metric_type'.
Removing this line resolved the error.

Below image is the error message.
<img width="991" height="507" alt="image" src="https://github.com/user-attachments/assets/e8911bc1-98fc-40bd-b745-c2350d1171a0" />
