### PR TITLE
Add S3vectors cli support

### DIFF
--- a/vectordb_bench/backend/clients/s3_vectors/cli.py
+++ b/vectordb_bench/backend/clients/s3_vectors/cli.py
@@ -1,0 +1,51 @@
+from typing import Annotated, TypedDict, Unpack
+
+import click
+from pydantic import SecretStr
+
+from ....cli.cli import (
+    CommonTypedDict,
+    cli,
+    click_parameter_decorators_from_typed_dict,
+    get_custom_case_config,
+    run,
+)
+from .. import DB
+from .config import S3VectorsIndexConfig
+from ..api import MetricType
+
+
+class S3VectorsTypedDict(TypedDict):
+    region_name: Annotated[str, click.option("--region", type=str, help="AWS region for S3 bucket (eg. us-east-1)", default="us-east-1")]
+    access_key_id: Annotated[str, click.option("--access_key_id", type=str, help="AWS access key ID", required=True)]
+    secret_access_key: Annotated[str, click.option("--secret_access_key", type=str, help="AWS secret access key", required=True)]
+
+    bucket: Annotated[str, click.option("--bucket", type=str, help="S3 bucket name", required=True)]
+    index: Annotated[str, click.option("--index", type=str, help="Unique vector index name", default="vdbbench-index")]
+
+    metric: Annotated[str, click.option("--metric", type=str, help="Distance metric for vector similarity (e.g., 'cosine', 'euclidean').", default=None)]
+
+
+class S3VectorsIndexTypedDict(CommonTypedDict, S3VectorsTypedDict): ...
+
+
+@cli.command()
+@click_parameter_decorators_from_typed_dict(S3VectorsIndexTypedDict)
+def S3Vectors(**parameters: Unpack[S3VectorsIndexTypedDict]):
+    from .config import S3VectorsConfig
+
+    parameters["custom_case"] = get_custom_case_config(parameters)
+    run(
+        db=DB.S3Vectors,
+        db_config=S3VectorsConfig(
+            region_name=parameters["region"],
+            access_key_id=SecretStr(parameters["access_key_id"]),
+            secret_access_key=SecretStr(parameters["secret_access_key"]),
+            bucket_name=parameters["bucket"],
+            index_name=parameters["index"] if parameters["index"] else "vdbbench-index",
+        ),
+        db_case_config=S3VectorsIndexConfig(
+            metric_type= MetricType.COSINE if parameters["metric"] == "cosine" else MetricType.L2 if parameters["metric"] == "l2" else None
+        ),
+        **parameters,
+    )

--- a/vectordb_bench/backend/clients/s3_vectors/cli.py
+++ b/vectordb_bench/backend/clients/s3_vectors/cli.py
@@ -11,19 +11,31 @@ from ....cli.cli import (
     run,
 )
 from .. import DB
-from .config import S3VectorsIndexConfig
 from ..api import MetricType
+from .config import S3VectorsIndexConfig
 
 
 class S3VectorsTypedDict(TypedDict):
-    region_name: Annotated[str, click.option("--region", type=str, help="AWS region for S3 bucket (eg. us-east-1)", default="us-east-1")]
+    region_name: Annotated[
+        str, click.option("--region", type=str, help="AWS region for S3 bucket (eg. us-east-1)", default="us-east-1")
+    ]
     access_key_id: Annotated[str, click.option("--access_key_id", type=str, help="AWS access key ID", required=True)]
-    secret_access_key: Annotated[str, click.option("--secret_access_key", type=str, help="AWS secret access key", required=True)]
+    secret_access_key: Annotated[
+        str, click.option("--secret_access_key", type=str, help="AWS secret access key", required=True)
+    ]
 
     bucket: Annotated[str, click.option("--bucket", type=str, help="S3 bucket name", required=True)]
     index: Annotated[str, click.option("--index", type=str, help="Unique vector index name", default="vdbbench-index")]
 
-    metric: Annotated[str, click.option("--metric", type=str, help="Distance metric for vector similarity (e.g., 'cosine', 'euclidean').", default=None)]
+    metric: Annotated[
+        str,
+        click.option(
+            "--metric",
+            type=str,
+            help="Distance metric for vector similarity (e.g., 'cosine', 'euclidean').",
+            default=None,
+        ),
+    ]
 
 
 class S3VectorsIndexTypedDict(CommonTypedDict, S3VectorsTypedDict): ...
@@ -45,8 +57,11 @@ def S3Vectors(**parameters: Unpack[S3VectorsIndexTypedDict]):
             index_name=parameters["index"] if parameters["index"] else "vdbbench-index",
         ),
         db_case_config=S3VectorsIndexConfig(
-            metric_type= MetricType.COSINE if parameters["metric"] == "cosine" else MetricType.L2 if parameters["metric"] == "l2" else None
+            metric_type=(
+                MetricType.COSINE
+                if parameters["metric"] == "cosine"
+                else MetricType.L2 if parameters["metric"] == "l2" else None
+            )
         ),
         **parameters,
     )
-

--- a/vectordb_bench/backend/clients/s3_vectors/cli.py
+++ b/vectordb_bench/backend/clients/s3_vectors/cli.py
@@ -49,3 +49,4 @@ def S3Vectors(**parameters: Unpack[S3VectorsIndexTypedDict]):
         ),
         **parameters,
     )
+

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -15,6 +15,7 @@ from ..backend.clients.pgvectorscale.cli import PgVectorScaleDiskAnn
 from ..backend.clients.qdrant_cloud.cli import QdrantCloud
 from ..backend.clients.qdrant_local.cli import QdrantLocal
 from ..backend.clients.redis.cli import Redis
+from ..backend.clients.s3_vectors.cli import S3Vectors
 from ..backend.clients.test.cli import Test
 from ..backend.clients.tidb.cli import TiDB
 from ..backend.clients.vespa.cli import Vespa
@@ -48,6 +49,7 @@ cli.add_command(HologresHGraph)
 cli.add_command(QdrantCloud)
 cli.add_command(QdrantLocal)
 cli.add_command(BatchCli)
+cli.add_command(S3Vectors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added S3Vectors cli support as discussed in #589 with @alwayslove2013, following instructions on the main [README](https://github.com/zilliztech/VectorDBBench?tab=readme-ov-file#custom-dataset-for-performance-case) file.

As it can be seen on the following logs, the changes seem to work using a custom dataset on my AWS account.

```bash
vectordbbench s3vectors --access_key_id <KEY_ID> --secret_access_key <SECRET_KEY> --bucket <BUCKET_NAME> --index test-cli --skip-search-concurrent --case-type PerformanceCustomDataset --custom-dataset-dir /home/acando/Documents/VectorDBBench/deep_100k_parquet/ --custom-dataset-size 100000 --custom-dataset-dim 96 --custom-dataset-file-count 1 --custom-case-name Custom --custom-dataset-name Deep_100k --custom-case-description TestDescription --custom-dataset-metric-type L2 --custom-case-load-timeout 36000 --custom-case-optimize-timeout 36000 --k 10
2025-09-12 11:31:00,259 | INFO: Task:
TaskConfig(db=<DB.S3Vectors: 'S3Vectors'>, db_config=S3VectorsConfig(db_label='', version='', note='', region_name='us-east-1', access_key_id=SecretStr('**********'), secret_access_key=SecretStr('**********'), bucket_name='<SECRET_NAME>', index_name='test-cli'), db_case_config=S3VectorsIndexConfig(metric_type=None, data_type='float32'), case_config=CaseConfig(case_id=<CaseType.PerformanceCustomDataset: 101>, custom_case={'name': 'Custom', 'description': 'TestDescription', 'load_timeout': 36000, 'optimize_timeout': 36000, 'dataset_config': {'name': 'Deep_100k', 'dir': '/home/acando/Documents/VectorDBBench/deep_100k_parquet/', 'size': '100000', 'dim': '96', 'metric_type': 'L2', 'file_count': '1', 'use_shuffled': False, 'with_gt': True}}, k=10, concurrency_search_config=ConcurrencySearchConfig(num_concurrency=[1, 5, 10, 20, 30, 40, 60, 80], concurrency_duration=30, concurrency_timeout=3600)), stages=['drop_old', 'load', 'search_serial'])
 (cli.py:635) (91144)
2025-09-12 11:31:00,259 | INFO: generated uuid for the tasks: c047b42a617d4bb5a0e6a0a0eef2aa24 (interface.py:76) (91144)
2025-09-12 11:31:00,353 | INFO | DB             | CaseType     Dataset               Filter | task_label (task_runner.py:380)
2025-09-12 11:31:00,353 | INFO | -----------    | ------------ -------------------- ------- | -------    (task_runner.py:380)
2025-09-12 11:31:00,353 | INFO | S3Vectors      | Performance  Deep_100k-Custom-100K     0.0 | c047b42a617d4bb5a0e6a0a0eef2aa24 (task_runner.py:380)
2025-09-12 11:31:00,353 | INFO: task submitted: id=c047b42a617d4bb5a0e6a0a0eef2aa24, c047b42a617d4bb5a0e6a0a0eef2aa24, case number: 1 (interface.py:251) (91144)
2025-09-12 11:31:01,023 | INFO: [1/1] start case: {'label': <CaseLabel.Performance: 2>, 'name': 'Custom', 'dataset': {'data': {'name': 'Deep_100k', 'size': 100000, 'dim': 96, 'metric_type': <MetricType.L2: 'L2'>}}, 'db': 'S3Vectors'}, drop_old=True (interface.py:181) (91174)
2025-09-12 11:31:01,023 | INFO: Starting run (task_runner.py:118) (91174)
2025-09-12 11:31:04,814 | INFO: drop old index: test-cli (s3_vectors.py:62) (91174)
2025-09-12 11:31:05,224 | INFO: Read the entire file into memory: test.parquet (dataset.py:392) (91174)
2025-09-12 11:31:05,236 | INFO: Read the entire file into memory: neighbors.parquet (dataset.py:392) (91174)
2025-09-12 11:31:05,238 | INFO: Start performance case (task_runner.py:163) (91174)
2025-09-12 11:31:06,122 | INFO: (SpawnProcess-1:1) Start inserting embeddings in batch 100000 (serial_runner.py:56) (91289)
2025-09-12 11:31:06,123 | INFO: Get iterator for train.parquet (dataset.py:413) (91289)
2025-09-12 11:33:27,458 | INFO: (SpawnProcess-1:1) Loaded 100000 embeddings into VectorDB (serial_runner.py:93) (91289)
2025-09-12 11:33:27,461 | INFO: (SpawnProcess-1:1) Finish loading all dataset into VectorDB, dur=141.33806637599992 (serial_runner.py:95) (91289)
2025-09-12 11:33:28,983 | INFO: Finish loading the entire dataset into VectorDB, insert_duration=142.5339538799999, optimize_duration=0.04706261700084724 load_duration(insert + optimize) = 142.581 (task_runner.py:173) (91174)
2025-09-12 11:33:28,984 | INFO: SpawnProcess-1 start serial search (serial_runner.py:304) (91174)
2025-09-12 11:33:30,098 | INFO: SpawnProcess-1:3 start search the entire test_data to get recall and latency (serial_runner.py:245) (93383)
2025-09-12 11:38:27,776 | INFO: SpawnProcess-1:3 search entire test_data: cost=297.5491s, queries=1000, avg_recall=0.9526, avg_ndcg=0.9677, avg_latency=0.2975, p99=0.7165, p95=0.4804 (serial_runner.py:285) (93383)
2025-09-12 11:38:27,959 | INFO: Performance case got result: Metric(max_load_count=0, insert_duration=142.534, optimize_duration=0.0471, load_duration=142.581, qps=0.0, serial_latency_p99=np.float64(0.7165), serial_latency_p95=np.float64(0.4804), recall=np.float64(0.9526), ndcg=np.float64(0.9677), conc_num_list=[], conc_qps_list=[], conc_latency_p99_list=[], conc_latency_p95_list=[], conc_latency_avg_list=[], st_ideal_insert_duration=0, st_search_stage_list=[], st_search_time_list=[], st_max_qps_list_list=[], st_recall_list=[], st_ndcg_list=[], st_serial_latency_p99_list=[], st_serial_latency_p95_list=[], st_conc_failed_rate_list=[]) (task_runner.py:201) (91174)
2025-09-12 11:38:27,959 | INFO: [1/1] finish case: {'label': <CaseLabel.Performance: 2>, 'name': 'Custom', 'dataset': {'data': {'name': 'Deep_100k', 'size': 100000, 'dim': 96, 'metric_type': <MetricType.L2: 'L2'>}}, 'db': 'S3Vectors'}, result=Metric(max_load_count=0, insert_duration=142.534, optimize_duration=0.0471, load_duration=142.581, qps=0.0, serial_latency_p99=np.float64(0.7165), serial_latency_p95=np.float64(0.4804), recall=np.float64(0.9526), ndcg=np.float64(0.9677), conc_num_list=[], conc_qps_list=[], conc_latency_p99_list=[], conc_latency_p95_list=[], conc_latency_avg_list=[], st_ideal_insert_duration=0, st_search_stage_list=[], st_search_time_list=[], st_max_qps_list_list=[], st_recall_list=[], st_ndcg_list=[], st_serial_latency_p99_list=[], st_serial_latency_p95_list=[], st_conc_failed_rate_list=[]), label=ResultLabel.NORMAL (interface.py:183) (91174)
2025-09-12 11:38:27,960 | INFO |Task summary: run_id=c047b, task_label=c047b42a617d4bb5a0e6a0a0eef2aa24 (models.py:438)
2025-09-12 11:38:27,961 | INFO |DB        | db_label case   label                            | load_dur    qps        latency(p99)    latency(p95)    recall        max_load_count | label (models.py:438)
2025-09-12 11:38:27,961 | INFO |--------- | -------- ------ -------------------------------- | ----------- ---------- --------------- --------------- ------------- -------------- | ----- (models.py:438)
2025-09-12 11:38:27,961 | INFO |S3Vectors |          Custom c047b42a617d4bb5a0e6a0a0eef2aa24 | 142.581     0.0        0.7165          0.4804          0.9526        0              | :)    (models.py:438)
2025-09-12 11:38:27,961 | INFO: write results to disk /home/acando/Documents/VectorDBBench/.venv/lib/python3.12/site-packages/vectordb_bench/results/S3Vectors/result_20250912_c047b42a617d4bb5a0e6a0a0eef2aa24_s3vectors.json (models.py:275) (91174)
2025-09-12 11:38:27,962 | INFO: Success to finish task: label=c047b42a617d4bb5a0e6a0a0eef2aa24, run_id=c047b42a617d4bb5a0e6a0a0eef2aa24 (interface.py:222) (91174)
```