### PR TITLE
awsopensearch add normalize for cosine similarity when indexing data

### DIFF
--- a/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
@@ -65,11 +65,11 @@ class AWSOpenSearch(VectorDB):
             self._load_graphs_to_memory(client)
 
     def need_normalize_cosine(self) -> bool:
-        if self.case_config.metric_type.upper() == 'COSINE':
+        if self.case_config.metric_type.upper() == "COSINE":
             log.info("cosine dataset need normalize.")
             return True
         return False
-        
+
     def _create_index(self, client: OpenSearch) -> None:
         ef_search_value = self.case_config.ef_search
         log.info(f"Creating index with ef_search: {ef_search_value}")


### PR DESCRIPTION
awsopensearch add normalize for cosine similarity, solved issue of recall rate with Cohere dataset
