### PR TITLE
feat(oss-opensearch): Add KNN derived source configuration option

### DIFF
--- a/vectordb_bench/backend/clients/oss_opensearch/config.py
+++ b/vectordb_bench/backend/clients/oss_opensearch/config.py
@@ -77,6 +77,7 @@ class OSSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
     oversample_factor: float = 1.0
     quantization_type: OSSOpenSearchQuantization = OSSOpenSearchQuantization.fp32
     replication_type: str | None = "DOCUMENT"
+    knn_derived_source_enabled: bool = False
 
     @root_validator
     def validate_engine_name(cls, values: dict):
@@ -103,6 +104,7 @@ class OSSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
             and self.use_routing == obj.use_routing
             and self.quantization_type == obj.quantization_type
             and self.replication_type == obj.replication_type
+            and self.knn_derived_source_enabled == obj.knn_derived_source_enabled
         )
 
     def __hash__(self) -> int:
@@ -117,6 +119,7 @@ class OSSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
                 self.use_routing,
                 self.quantization_type,
                 self.replication_type,
+                self.knn_derived_source_enabled,
             )
         )
 

--- a/vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py
+++ b/vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py
@@ -27,6 +27,11 @@ VERSION_SPECIFIC_SETTING_RULES = [
         "applies": lambda version, _: version >= Version("3.0"),
         "value": lambda _: "-1",
     },
+    {
+        "name": "knn.derived_source.enabled",
+        "applies": lambda version, _: version >= Version("3.0"),
+        "value": lambda case_config: case_config.knn_derived_source_enabled,
+    },
 ]
 
 
@@ -270,6 +275,7 @@ class OSSOpenSearch(VectorDB):
         log.info(f"Creating index with ef_search: {ef_search_value}")
         log.info(f"Creating index with number_of_replicas: {self.case_config.number_of_replicas}")
         log.info(f"Creating index with replication_type: {self.case_config.replication_type}")
+        log.info(f"Creating index with knn_derived_source_enabled: {self.case_config.knn_derived_source_enabled}")
         log.info(f"Creating index with engine: {self.case_config.engine}")
         log.info(f"Creating index with metric type: {self.case_config.metric_type_name}")
         log.info(f"All case_config parameters: {self.case_config.__dict__}")

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -1848,6 +1848,16 @@ CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch = CaseConfigInput(
     },
 )
 
+CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.knn_derived_source_enabled,
+    displayLabel="KNN Derived Source Enabled",
+    inputHelp="Enable KNN derived source (OpenSearch 3.x+ only). Ignored for 2.x versions.",
+    inputType=InputType.Bool,
+    inputConfig={
+        "value": False,
+    },
+)
+
 MilvusLoadConfig = [
     CaseConfigParamInput_IndexType,
     CaseConfigParamInput_M,
@@ -1929,12 +1939,14 @@ AWSOpensearchLoadingConfig = [
     CaseConfigParamInput_EFConstruction_AWSOpensearch,
     CaseConfigParamInput_M_AWSOpensearch,
     CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,
+    CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch,
 ]
 AWSOpenSearchPerformanceConfig = [
     CaseConfigParamInput_EFConstruction_AWSOpensearch,
     CaseConfigParamInput_M_AWSOpensearch,
     CaseConfigParamInput_EF_SEARCH_AWSOpensearch,
     CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,
+    CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch,
 ]
 
 AliyunOpensearchLoadingConfig = []
@@ -2274,6 +2286,7 @@ AWSOpensearchLoadingConfig = [
     CaseConfigParamInput_EFConstruction_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_SHARDS_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_REPLICAS_AWSOpensearch,
+    CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_INDEXING_CLIENTS_AWSOpensearch,
     CaseConfigParamInput_INDEX_THREAD_QTY_AWSOpensearch,
     CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,
@@ -2289,6 +2302,7 @@ AWSOpenSearchPerformanceConfig = [
     CaseConfigParamInput_EFConstruction_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_SHARDS_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_REPLICAS_AWSOpensearch,
+    CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_INDEXING_CLIENTS_AWSOpensearch,
     CaseConfigParamInput_INDEX_THREAD_QTY_AWSOpensearch,
     CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -127,6 +127,7 @@ class CaseConfigParamType(Enum):
     oversample_ratio = "oversample_ratio"
     use_routing = "use_routing"
     replication_type = "replication_type"
+    knn_derived_source_enabled = "knn_derived_source_enabled"
 
     # CockroachDB parameters
     min_partition_size = "min_partition_size"


### PR DESCRIPTION
## Problem
OpenSearch 3.x+ enables `knn.derived_source.enabled` by default, which allows OpenSearch to derive vectors from the vector values file instead of storing them in the `_source` field. However, users need a way to control this behavior for their specific use cases:
- When working with different OpenSearch versions because this feature was not be available (< 3.x)
- When they want to disable this feature to store vectors in `_source` for specific requirements

## Solution
Added a new configurable option `knn_derived_source_enabled` allowing users to:
- **"None" (default)** - Skip setting for OpenSearch < 3.x compatibility
- **"True"** - Explicitly enable (3.x+ default behavior)
- **"False"** - Disable for better performance on 3.x+

## Changes
- Added `knn_derived_source_enabled: str | None = None` field to `OSSOpenSearchIndexConfig`
- Conditional setting in `_create_index()` - only added when explicitly set
- UI dropdown with 3 options and version guidance
- Added enum to `CaseConfigParamType`

## Benefits
- ✅ Version-compatible (OpenSearch < 3.x and 3.x+)
- ✅ User-friendly UI with clear guidance
- ✅ No breaking changes - default behavior unchanged

## Files Changed
- `vectordb_bench/backend/clients/oss_opensearch/config.py`
- `vectordb_bench/models.py`
- `vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py`
- `vectordb_bench/frontend/config/dbCaseConfigs.py`

## Screenshots
<img width="1421" height="804" alt="Screenshot 2025-11-07 at 17 04 59" src="https://github.com/user-attachments/assets/d98b39fb-0d1b-4e41-a884-bb16a05f96cf" />
