### PR TITLE
feat(oss-opensearch): Add version compatibility for 2.x and 3.x

### DIFF
--- a/install/requirements_py3.11.txt
+++ b/install/requirements_py3.11.txt
@@ -25,3 +25,4 @@ pymilvus
 clickhouse_connect
 pyvespa
 mysql-connector-python
+packaging


### PR DESCRIPTION
### Summary

This PR adds version compatibility to the OpenSearch client, allowing it to work correctly with both OpenSearch 2.x and 3.x clusters. It resolves a critical issue where 3.x-specific index settings were being sent to 2.x clusters, causing index creation to fail.

### Changes

*   Added robust version detection using the `.info()` API and the `packaging` library for accurate semantic version comparisons.
*   Implemented an extensible, declarative registry (`VERSION_SPECIFIC_SETTING_RULES`) to apply only compatible settings based on the detected cluster version.
*   Established a "Fail-Fast" error handling strategy that raises an exception if the cluster version cannot be determined, preventing ambiguous states.

### Files Modified

*   `vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py`
*   `install/requirements_py3.11.txt`

### Key Features

✅ **Backward Compatible**: Now works with OpenSearch 2.x clusters.
✅ **Future-Proof**: The new design makes it trivial to add rules for future OpenSearch versions.
✅ **Robust Error Handling**: Prevents ambiguous states by failing fast if the cluster version is unknown.