### PR TITLE
Update cli.py fix bug (#649)

### DIFF
--- a/vectordb_bench/cli/cli.py
+++ b/vectordb_bench/cli/cli.py
@@ -652,3 +652,6 @@ def run(
         time.sleep(5)
         if global_result_future:
             wait([global_result_future])
+
+        while benchmark_runner.has_running():
+            time.sleep(1)


### PR DESCRIPTION
root cause: #649 
how to fix:
The front-end UI periodically calls benchmark_runner.has_running() to refresh the progress bar. This incidentally consumes the SUCCESS signal, and the running_task will be properly cleaned up. Therefore, the front-end process is OK. So my fix fully reuses the existing public API: benchmark_runner.has_running(), which is consistent with the front-end usage.