### PR TITLE
feat: Add Custom Dataset support for Streaming Tests

### DIFF
--- a/vectordb_bench/custom/custom_case.json
+++ b/vectordb_bench/custom/custom_case.json
@@ -14,5 +14,18 @@
             "use_shuffled": false,
             "with_gt": true
         }
+    },
+    {
+        "case_type": "streaming",
+        "description": "This is a custom streaming dataset.",
+        "dataset_config": {
+            "name": "My Streaming Dataset",
+            "dir": "/my_dataset_path",
+            "size": 1000000,
+            "dim": 1024,
+            "file_count": 1,
+            "train_name": "shuffle_train",
+            "with_gt": true
+        }
     }
 ]

--- a/vectordb_bench/frontend/components/custom/displayCustomStreamingCase.py
+++ b/vectordb_bench/frontend/components/custom/displayCustomStreamingCase.py
@@ -1,0 +1,49 @@
+from vectordb_bench.frontend.components.custom.getCustomConfig import CustomStreamingCaseConfig
+
+
+def displayCustomStreamingCase(streamingCase: CustomStreamingCaseConfig, st, key):
+
+    columns = st.columns([1, 2])
+    streamingCase.dataset_config.name = columns[0].text_input(
+        "Name", key=f"{key}_name", value=streamingCase.dataset_config.name
+    )
+    streamingCase.dataset_config.dir = columns[1].text_input(
+        "Folder Path", key=f"{key}_dir", value=streamingCase.dataset_config.dir
+    )
+
+    columns = st.columns(2)
+    streamingCase.dataset_config.dim = columns[0].number_input(
+        "dim", key=f"{key}_dim", value=streamingCase.dataset_config.dim
+    )
+    streamingCase.dataset_config.size = columns[1].number_input(
+        "size", key=f"{key}_size", value=streamingCase.dataset_config.size
+    )
+
+    columns = st.columns(3)
+    streamingCase.dataset_config.train_name = columns[0].text_input(
+        "train file name",
+        key=f"{key}_train_name",
+        value=streamingCase.dataset_config.train_name,
+    )
+    streamingCase.dataset_config.test_name = columns[1].text_input(
+        "test file name", key=f"{key}_test_name", value=streamingCase.dataset_config.test_name
+    )
+    streamingCase.dataset_config.gt_name = columns[2].text_input(
+        "ground truth file name", key=f"{key}_gt_name", value=streamingCase.dataset_config.gt_name
+    )
+
+    columns = st.columns([1, 1, 2, 2])
+    streamingCase.dataset_config.train_id_name = columns[0].text_input(
+        "train id name", key=f"{key}_train_id_name", value=streamingCase.dataset_config.train_id_name
+    )
+    streamingCase.dataset_config.train_col_name = columns[1].text_input(
+        "train emb name", key=f"{key}_train_col_name", value=streamingCase.dataset_config.train_col_name
+    )
+    streamingCase.dataset_config.test_col_name = columns[2].text_input(
+        "test emb name", key=f"{key}_test_col_name", value=streamingCase.dataset_config.test_col_name
+    )
+    streamingCase.dataset_config.gt_col_name = columns[3].text_input(
+        "ground truth emb name", key=f"{key}_gt_col_name", value=streamingCase.dataset_config.gt_col_name
+    )
+
+    streamingCase.description = st.text_area("description", key=f"{key}_description", value=streamingCase.description)

--- a/vectordb_bench/frontend/components/custom/getCustomConfig.py
+++ b/vectordb_bench/frontend/components/custom/getCustomConfig.py
@@ -34,10 +34,30 @@ class CustomCaseConfig(BaseModel):
     dataset_config: CustomDatasetConfig = CustomDatasetConfig()
 
 
+class CustomStreamingCaseConfig(BaseModel):
+    case_type: str = "streaming"
+    description: str = ""
+    dataset_config: CustomDatasetConfig = CustomDatasetConfig()
+
+
 def get_custom_configs():
     with open(config.CUSTOM_CONFIG_DIR, "r") as f:
         custom_configs = json.load(f)
-        return [CustomCaseConfig(**custom_config) for custom_config in custom_configs]
+        return [
+            CustomCaseConfig(**custom_config)
+            for custom_config in custom_configs
+            if custom_config.get("case_type") != "streaming"
+        ]
+
+
+def get_custom_streaming_configs():
+    with open(config.CUSTOM_CONFIG_DIR, "r") as f:
+        custom_configs = json.load(f)
+        return [
+            CustomStreamingCaseConfig(**custom_config)
+            for custom_config in custom_configs
+            if custom_config.get("case_type") == "streaming"
+        ]
 
 
 def save_custom_configs(custom_configs: list[CustomDatasetConfig]):
@@ -45,5 +65,18 @@ def save_custom_configs(custom_configs: list[CustomDatasetConfig]):
         json.dump([custom_config.dict() for custom_config in custom_configs], f, indent=4)
 
 
+def save_all_custom_configs(
+    performance_configs: list[CustomCaseConfig], streaming_configs: list[CustomStreamingCaseConfig]
+):
+    """Save both performance and streaming configs to the same JSON file"""
+    all_configs = [config.dict() for config in performance_configs] + [config.dict() for config in streaming_configs]
+    with open(config.CUSTOM_CONFIG_DIR, "w") as f:
+        json.dump(all_configs, f, indent=4)
+
+
 def generate_custom_case():
     return CustomCaseConfig()
+
+
+def generate_custom_streaming_case():
+    return CustomStreamingCaseConfig()

--- a/vectordb_bench/frontend/components/run_test/caseSelector.py
+++ b/vectordb_bench/frontend/components/run_test/caseSelector.py
@@ -7,6 +7,7 @@ from vectordb_bench.frontend.config.dbCaseConfigs import (
     UICaseItemCluster,
     get_case_config_inputs,
     get_custom_case_cluter,
+    get_custom_streaming_case_cluster,
 )
 from vectordb_bench.frontend.config.styles import (
     CASE_CONFIG_SETTING_COLUMNS,
@@ -32,7 +33,7 @@ def caseSelector(st, activedDbList: list[DB]):
     activedCaseList: list[CaseConfig] = []
     dbToCaseClusterConfigs = defaultdict(lambda: defaultdict(dict))
     dbToCaseConfigs = defaultdict(lambda: defaultdict(dict))
-    caseClusters = UI_CASE_CLUSTERS + [get_custom_case_cluter()]
+    caseClusters = UI_CASE_CLUSTERS + [get_custom_case_cluter(), get_custom_streaming_case_cluster()]
     for caseCluster in caseClusters:
         activedCaseList += caseClusterExpander(st, caseCluster, dbToCaseClusterConfigs, activedDbList)
     for db in dbToCaseClusterConfigs:

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -161,6 +161,34 @@ def get_custom_case_cluter() -> UICaseItemCluster:
     return UICaseItemCluster(label="Custom Search Performance Test", uiCaseItems=get_custom_case_items())
 
 
+def get_custom_streaming_case_items() -> list[UICaseItem]:
+    from vectordb_bench.frontend.components.custom.getCustomConfig import get_custom_streaming_configs
+
+    custom_streaming_configs = get_custom_streaming_configs()
+    return [
+        UICaseItem(
+            label=f"{custom_config.dataset_config.name} - Streaming",
+            description=f"Streaming test with custom dataset: {custom_config.dataset_config.name}",
+            cases=[
+                CaseConfig(
+                    case_id=CaseType.StreamingCustomDataset,
+                    custom_case={
+                        "description": custom_config.description,
+                        "dataset_config": custom_config.dataset_config.dict(),
+                    },
+                )
+            ],
+            caseLabel=CaseLabel.Streaming,
+            extra_custom_case_config_inputs=custom_streaming_config_with_custom_dataset,
+        )
+        for custom_config in custom_streaming_configs
+    ]
+
+
+def get_custom_streaming_case_cluster() -> UICaseItemCluster:
+    return UICaseItemCluster(label="Custom Streaming Test", uiCaseItems=get_custom_streaming_case_items())
+
+
 def generate_custom_streaming_case() -> CaseConfig:
     return CaseConfig(
         case_id=CaseType.StreamingPerformanceCase,
@@ -205,6 +233,12 @@ custom_streaming_config: list[ConfigInput] = [
         inputConfig=dict(step=10, min=30, max=360_000, value=30),
         inputHelp="search test duration after inserting all data",
     ),
+]
+
+# Config for custom streaming tests (with custom dataset from JSON)
+# Filter out the dataset_with_size_type from the existing config
+custom_streaming_config_with_custom_dataset: list[ConfigInput] = [
+    config for config in custom_streaming_config if config.label != CaseConfigParamType.dataset_with_size_type
 ]
 
 


### PR DESCRIPTION
## Summary
VectorDBBench supports custom datasets for **Performance Tests** (search-only benchmarks). This PR extends that support to **Streaming Tests** (concurrent insertion + search benchmarks), enabling users to evaluate streaming performance on their domain-specific or proprietary datasets—a critical capability for production workload simulation.

## Changes
- **Backend**: Extended `StreamingPerformanceCase` to accept custom dataset configurations
- **Frontend - Run Test Page**: Added new "Custom Streaming Test" cluster displaying custom streaming datasets as individual checkboxes
- **Frontend - Custom Page**: Added dedicated streaming dataset management section with create/edit/delete functionality
- **Configuration**: Added `case_type` field to differentiate streaming and performance datasets in `custom_case.json`

## New Files
- `vectordb_bench/frontend/components/custom/displayCustomStreamingCase.py`

## Modified Files
- `vectordb_bench/backend/cases.py`
- `vectordb_bench/frontend/components/custom/getCustomConfig.py`
- `vectordb_bench/frontend/config/dbCaseConfigs.py`
- `vectordb_bench/frontend/components/run_test/caseSelector.py`
- `vectordb_bench/frontend/pages/custom.py`
- `vectordb_bench/custom/custom_case.json`

## User Workflow
1. Navigate to `/custom` page
2. Add new streaming dataset in "Streaming Test Datasets" section
3. Configure dataset parameters (name, path, dimensions, file names, etc.)
4. Save configuration
5. Navigate to `/run_test` page
6. Select custom streaming dataset from "Custom Streaming Test" cluster
7. Configure streaming parameters (insert_rate, search_stages, concurrencies)
8. Run test

## Testing
- [x] Custom streaming dataset can be created and saved
- [x] Custom streaming dataset appears in "Custom Streaming Test"
- [x] Streaming test runs successfully with custom dataset
- [x] Multiple training files are loaded correctly

## Screenshots
<img width="1864" height="990" alt="Screenshot 2025-12-02 at 01 24 27" src="https://github.com/user-attachments/assets/78e8b4fe-2f1c-48d2-9d51-74c503e7ea16" />
<img width="1854" height="990" alt="Screenshot 2025-12-02 at 01 25 06" src="https://github.com/user-attachments/assets/2d2f8252-e769-4657-9eb0-bb72dbf83021" />
