### PR TITLE
Add benchmark result of Apache Doris in case Performance768D10M

### DIFF
--- a/vectordb_bench/results/Doris/result_20251203_2b724c1b542f4e9d919c0bb29810ef75_doris.json
+++ b/vectordb_bench/results/Doris/result_20251203_2b724c1b542f4e9d919c0bb29810ef75_doris.json
@@ -1,0 +1,106 @@
+{
+  "run_id": "2b724c1b542f4e9d919c0bb29810ef75",
+  "task_label": "2b724c1b542f4e9d919c0bb29810ef75",
+  "results": [
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 4397.4305,
+        "optimize_duration": 0.0077,
+        "load_duration": 4397.4382,
+        "qps": 447.2799,
+        "serial_latency_p99": 0.0614,
+        "serial_latency_p95": 0.0607,
+        "recall": 0.9199,
+        "ndcg": 0.921,
+        "conc_num_list": [
+          10,
+          30,
+          60,
+          90
+        ],
+        "conc_qps_list": [
+          0.1583,
+          341.3882,
+          439.4979,
+          447.2799
+        ],
+        "conc_latency_p99_list": [
+          63.18045730348676,
+          0.13251519890734928,
+          0.1968061485211365,
+          0.2906876397132873
+        ],
+        "conc_latency_p95_list": [
+          63.17947528138757,
+          0.11366299332585185,
+          0.1768655477790162,
+          0.2600868879817426
+        ],
+        "conc_latency_avg_list": [
+          63.17535177429672,
+          0.08755610804136403,
+          0.13603569020768128,
+          0.19992166596536262
+        ],
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": []
+      },
+      "task_config": {
+        "db": "Doris",
+        "db_config": {
+          "db_label": "2025-12-03T14:56:37.719734",
+          "version": "",
+          "note": "",
+          "user_name": "root",
+          "password": "",
+          "host": "172.20.50.130",
+          "port": 9030,
+          "http_port": 8030,
+          "db_name": "vdb",
+          "ssl": false
+        },
+        "db_case_config": {
+          "metric_type": "COSINE",
+          "m": null,
+          "ef_construction": null,
+          "index_properties": {},
+          "session_vars": {},
+          "stream_load_rows_per_batch": 500000,
+          "no_index": false
+        },
+        "case_config": {
+          "case_id": 4,
+          "custom_case": {},
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              10,
+              30,
+              60,
+              90
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ]
+      },
+      "label": ":)"
+    }
+  ],
+  "file_fmt": "result_{}_{}_{}.json",
+  "timestamp": 1764691200
+}

--- a/vectordb_bench/results/Doris/result_20251203_b0cc1496837e4af98484f67126db80c1_doris.json
+++ b/vectordb_bench/results/Doris/result_20251203_b0cc1496837e4af98484f67126db80c1_doris.json
@@ -1,0 +1,106 @@
+{
+  "run_id": "b0cc1496837e4af98484f67126db80c1",
+  "task_label": "b0cc1496837e4af98484f67126db80c1",
+  "results": [
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 0,
+        "optimize_duration": 0,
+        "load_duration": 0,
+        "qps": 258.4754,
+        "serial_latency_p99": 0.0665,
+        "serial_latency_p95": 0.0651,
+        "recall": 0.9717,
+        "ndcg": 0.9716,
+        "conc_num_list": [
+          10,
+          30,
+          60,
+          90
+        ],
+        "conc_qps_list": [
+          149.28,
+          252.9521,
+          256.7661,
+          258.4754
+        ],
+        "conc_latency_p99_list": [
+          0.08581630722619596,
+          0.16525912668788797,
+          0.33054610333405426,
+          0.4787712124641985
+        ],
+        "conc_latency_p95_list": [
+          0.0784195379819721,
+          0.1496453592320904,
+          0.2982652298524044,
+          0.43668921501375735
+        ],
+        "conc_latency_avg_list": [
+          0.06694095181089714,
+          0.11821960804550667,
+          0.23245239917642196,
+          0.3466133927825382
+        ],
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": []
+      },
+      "task_config": {
+        "db": "Doris",
+        "db_config": {
+          "db_label": "2025-12-03T16:30:09.299535",
+          "version": "",
+          "note": "",
+          "user_name": "root",
+          "password": "",
+          "host": "172.20.50.130",
+          "port": 9030,
+          "http_port": 8030,
+          "db_name": "vdb",
+          "ssl": false
+        },
+        "db_case_config": {
+          "metric_type": "COSINE",
+          "m": null,
+          "ef_construction": null,
+          "index_properties": {},
+          "session_vars": {
+            "hnsw_ef_search": "100"
+          },
+          "stream_load_rows_per_batch": 500000,
+          "no_index": false
+        },
+        "case_config": {
+          "case_id": 4,
+          "custom_case": {},
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              10,
+              30,
+              60,
+              90
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600
+          }
+        },
+        "stages": [
+          "search_serial",
+          "search_concurrent"
+        ]
+      },
+      "label": ":)"
+    }
+  ],
+  "file_fmt": "result_{}_{}_{}.json",
+  "timestamp": 1764691200
+}

--- a/vectordb_bench/results/Doris/result_20251203_da59309a6d48445db624be4849833d52_doris.json
+++ b/vectordb_bench/results/Doris/result_20251203_da59309a6d48445db624be4849833d52_doris.json
@@ -1,0 +1,106 @@
+{
+  "run_id": "da59309a6d48445db624be4849833d52",
+  "task_label": "da59309a6d48445db624be4849833d52",
+  "results": [
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 0,
+        "optimize_duration": 0,
+        "load_duration": 0,
+        "qps": 165.0201,
+        "serial_latency_p99": 0.0732,
+        "serial_latency_p95": 0.0714,
+        "recall": 0.9852,
+        "ndcg": 0.9849,
+        "conc_num_list": [
+          10,
+          30,
+          60,
+          90
+        ],
+        "conc_qps_list": [
+          121.1831,
+          164.3104,
+          165.0201,
+          163.6581
+        ],
+        "conc_latency_p99_list": [
+          0.10872276791837068,
+          0.2703677583113309,
+          0.5044047101540495,
+          0.7147008198546245
+        ],
+        "conc_latency_p95_list": [
+          0.10195920799160375,
+          0.24466251232661307,
+          0.46539584645070137,
+          0.6646372095565312
+        ],
+        "conc_latency_avg_list": [
+          0.08241292234512995,
+          0.1821913545497714,
+          0.3621327245552503,
+          0.5454047027612101
+        ],
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": []
+      },
+      "task_config": {
+        "db": "Doris",
+        "db_config": {
+          "db_label": "2025-12-03T16:15:31.533527",
+          "version": "",
+          "note": "",
+          "user_name": "root",
+          "password": "",
+          "host": "172.20.50.130",
+          "port": 9030,
+          "http_port": 8030,
+          "db_name": "vdb",
+          "ssl": false
+        },
+        "db_case_config": {
+          "metric_type": "COSINE",
+          "m": null,
+          "ef_construction": null,
+          "index_properties": {},
+          "session_vars": {
+            "hnsw_ef_search": "200"
+          },
+          "stream_load_rows_per_batch": 500000,
+          "no_index": false
+        },
+        "case_config": {
+          "case_id": 4,
+          "custom_case": {},
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              10,
+              30,
+              60,
+              90
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600
+          }
+        },
+        "stages": [
+          "search_serial",
+          "search_concurrent"
+        ]
+      },
+      "label": ":)"
+    }
+  ],
+  "file_fmt": "result_{}_{}_{}.json",
+  "timestamp": 1764691200
+}

--- a/vectordb_bench/results/dbPrices.json
+++ b/vectordb_bench/results/dbPrices.json
@@ -36,5 +36,8 @@
   "OpenSearch": {
     "16c128g": 1.418,
     "16c128g-force_merge": 1.418
+  },
+  "Doris": {
+    "16c64g": 0.248
   }
 }


### PR DESCRIPTION
Hello zilliz community. I've some benchmark result of Apache Doris on case Performance768D10M.

There are there result json, each represents a different recall level. You can reproduce the test result by following command line args.
```bash
NUM_PER_BATCH=500000 vectordbbench  doris --case-type=Performance768D10M --stream-load-rows-per-batch 500000 --host 172.20.50.130 --num-concurrency 10,30,60,90 --db-name vdb --skip-load --skip-drop-old --session-var hnsw_ef_search=100
```
You can change `hnsw_ef_search=100` in the range of 40,100,200 to get different recall result.

BTW, test is performed on a single 16C63G machine, and using binary from doris master, you can use this package:
http://justtmp-bj-1308700295.cos.ap-beijing.myqcloud.com/hzq/vector-index/20251203/master.zip