### PR TITLE
expose turbopuffer through CLI and make compatible with latest sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ all = [
     "pyvespa",
     "lancedb",
     "mysql-connector-python",
+    "turbopuffer[fast]",
 ]
 
 qdrant          = [ "qdrant-client" ]
@@ -102,6 +103,7 @@ lancedb         = [ "lancedb" ]
 oceanbase       = [ "mysql-connector-python" ]
 alisql          = [ "mysql-connector-python" ]
 doris           = [ "doris-vector-search" ]
+turbopuffer     = [ "turbopuffer" ]
 
 [project.urls]
 "repository" = "https://github.com/zilliztech/VectorDBBench"

--- a/vectordb_bench/backend/clients/__init__.py
+++ b/vectordb_bench/backend/clients/__init__.py
@@ -55,7 +55,7 @@ class DB(Enum):
     TencentElasticsearch = "TencentElasticsearch"
     AliSQL = "AlibabaCloudRDSMySQL"
     Doris = "Doris"
-    TurboPuffer = "TurpoBuffer"
+    TurboPuffer = "TurboPuffer"
 
     @property
     def init_cls(self) -> type[VectorDB]:  # noqa: PLR0911, PLR0912, C901, PLR0915

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -1,0 +1,62 @@
+from typing import Annotated, TypedDict, Unpack
+
+import click
+from pydantic import SecretStr
+
+from ....cli.cli import (
+    CommonTypedDict,
+    cli,
+    click_parameter_decorators_from_typed_dict,
+    run,
+)
+from .. import DB
+
+
+class TurboPufferTypedDict(TypedDict):
+    api_key: Annotated[
+        str,
+        click.option("--api-key", type=str, help="TurboPuffer API key", required=True),
+    ]
+    api_base_url: Annotated[
+        str,
+        click.option(
+            "--api-base-url",
+            type=str,
+            help="TurboPuffer API base URL",
+            required=False,
+            default="https://api.turbopuffer.com",
+            show_default=True,
+        ),
+    ]
+    namespace: Annotated[
+        str,
+        click.option(
+            "--namespace",
+            type=str,
+            help="TurboPuffer namespace",
+            required=False,
+            default="vdbbench_test",
+            show_default=True,
+        ),
+    ]
+
+
+class TurboPufferIndexTypedDict(CommonTypedDict, TurboPufferTypedDict): ...
+
+
+@cli.command()
+@click_parameter_decorators_from_typed_dict(TurboPufferIndexTypedDict)
+def TurboPuffer(**parameters: Unpack[TurboPufferIndexTypedDict]):
+    from .config import TurboPufferConfig, TurboPufferIndexConfig
+
+    run(
+        db=DB.TurboPuffer,
+        db_config=TurboPufferConfig(
+            db_label=parameters["db_label"],
+            api_key=SecretStr(parameters["api_key"]),
+            api_base_url=parameters["api_base_url"],
+            namespace=parameters["namespace"],
+        ),
+        db_case_config=TurboPufferIndexConfig(),
+        **parameters,
+    )

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -22,6 +22,7 @@ from ..backend.clients.s3_vectors.cli import S3Vectors
 from ..backend.clients.tencent_elasticsearch.cli import TencentElasticsearch
 from ..backend.clients.test.cli import Test
 from ..backend.clients.tidb.cli import TiDB
+from ..backend.clients.turbopuffer.cli import TurboPuffer
 from ..backend.clients.vespa.cli import Vespa
 from ..backend.clients.weaviate_cloud.cli import Weaviate
 from ..backend.clients.zilliz_cloud.cli import ZillizAutoIndex
@@ -58,6 +59,7 @@ cli.add_command(S3Vectors)
 cli.add_command(TencentElasticsearch)
 cli.add_command(AliSQLHNSW)
 cli.add_command(Doris)
+cli.add_command(TurboPuffer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit includes two changes:
1. Make the turbopuffer client runnable as a subcommand in the CLI like so: `vectordbbench turbopuffer --help`
2. The turbopuffer API calls in the current client implementation appear to be using the python SDK that's prior to v0.5. v0.5 introduced breaking changes (see https://github.com/turbopuffer/turbopuffer-python/blob/main/UPGRADING.md). Updated the API calls to conform with the new SDK version.

Testing locally:
```
$ vectordbbench turbopuffer  --api-key SECRET --case-type Performance768D1M --namespace vdbbench  --skip-drop-old --skip-load

2025-12-04 20:17:32,128 | INFO: Task:
TaskConfig(db=<DB.TurboPuffer: 'TurboPuffer'>, db_config=TurboPufferConfig(db_label='2025-12-04T20:17:32.061781', version='', note='', api_key=SecretStr('**********'), api_base_url='https://api.turbopuffer.com', namespace='vdbbench'), db_case_config=TurboPufferIndexConfig(metric_type=None, use_multi_ns_for_filter=False, time_wait_warmup=60), case_config=CaseConfig(case_id=<CaseType.Performance768D1M: 5>, custom_case={}, k=100, concurrency_search_config=ConcurrencySearchConfig(num_concurrency=[1, 5, 10, 20, 30, 40, 60, 80], concurrency_duration=30, concurrency_timeout=3600)), stages=['search_serial', 'search_concurrent'])
 (cli.py:649) (43040)
2025-12-04 20:17:32,128 | INFO: generated uuid for the tasks: cd18598c871d4b99a3ad5e1863cc4947 (interface.py:76) (43040)
2025-12-04 20:17:32,309 | INFO | DB             | CaseType     Dataset               Filter | task_label (task_runner.py:400)
2025-12-04 20:17:32,310 | INFO | -----------    | ------------ -------------------- ------- | -------    (task_runner.py:400)
2025-12-04 20:17:32,310 | INFO | TurboPuffer-2025-12-04T20:17:32.061781 | Performance  Cohere-MEDIUM-1M         0.0 | cd18598c871d4b99a3ad5e1863cc4947 (task_runner.py:400)
2025-12-04 20:17:32,310 | INFO: task submitted: id=cd18598c871d4b99a3ad5e1863cc4947, cd18598c871d4b99a3ad5e1863cc4947, case number: 1 (interface.py:251) (43040)
2025-12-04 20:17:33,032 | INFO: [1/1] start case: {'label': <CaseLabel.Performance: 2>, 'name': 'Search Performance Test (1M Dataset, 768 Dim)', 'dataset': {'data': {'name': 'Cohere', 'size': 1000000, 'dim': 768, 'metric_type': <MetricType.COSINE: 'COSINE'>}}, 'db': 'TurboPuffer-2025-12-04T20:17:32.061781'}, drop_old=False (interface.py:181) (43105)
2025-12-04 20:17:33,033 | INFO: Starting run (task_runner.py:138) (43105)
2025-12-04 20:17:33,341 | INFO: local dataset root path not exist, creating it: /tmp/vectordb_bench/dataset/cohere/cohere_medium_1m (data_source.py:124) (43105)
2025-12-04 20:17:33,341 | INFO: Start to downloading files, total count: 4 (data_source.py:140) (43105)
 25%|███████████████████████████▊                                                                                   | 1 50%|███████████████████████████████████████████████████████▌                                                       | 2 75%|███████████████████████████████████████████████████████████████████████████████████▎                           | 3100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:48<00:00, 12.19s/it]
2025-12-04 20:18:22,119 | INFO: Succeed to download all files, downloaded file count = 4 (data_source.py:145) (43105)
2025-12-04 20:18:22,119 | INFO: Read the entire file into memory: test.parquet (dataset.py:392) (43105)
2025-12-04 20:18:22,160 | INFO: Read the entire file into memory: neighbors.parquet (dataset.py:392) (43105)
2025-12-04 20:18:22,214 | INFO: Start performance case (task_runner.py:183) (43105)
2025-12-04 20:18:22,945 | INFO: Start search 30s in concurrency 1, filters: type=<FilterOp.NonFilter: 'NonFilter'> filter_rate=0.0 gt_file_name='neighbors.parquet' (mp_runner.py:116) (43105)
...
```