### PR TITLE
Custom log file placement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 LOG_LEVEL=INFO
-LOG_PATH="logs"
-LOG_NAME="vectordb_bench.log"
+LOG_FILE="logs/vectordb_bench.log"
 # TIMEZONE=
 
 # NUM_PER_BATCH=

--- a/vectordb_bench/__init__.py
+++ b/vectordb_bench/__init__.py
@@ -14,8 +14,7 @@ class config:
     AWS_S3_URL = "assets.zilliz.com/benchmark/"
 
     LOG_LEVEL = env.str("LOG_LEVEL", "INFO")
-    LOG_PATH = env.str("LOG_PATH", "logs")
-    LOG_NAME = env.str("LOG_NAME", "vectordb_bench.log")
+    LOG_FILE = env.str("LOG_FILE", "logs/vectordb_bench.log")
 
     DEFAULT_DATASET_URL = env.str("DEFAULT_DATASET_URL", AWS_S3_URL)
     DATASET_SOURCE = env.str("DATASET_SOURCE", "S3")  # Options "S3" or "AliyunOSS"
@@ -81,4 +80,4 @@ class config:
         ]
 
 
-log_util.init(config.LOG_LEVEL, pathlib.Path(config.LOG_PATH), config.LOG_NAME)
+log_util.init(config.LOG_LEVEL, pathlib.Path(config.LOG_FILE))

--- a/vectordb_bench/log_util.py
+++ b/vectordb_bench/log_util.py
@@ -3,10 +3,9 @@ from logging import config
 from pathlib import Path
 
 
-def init(log_level: str, log_dir: Path, log_name: str):
+def init(log_level: str, log_file: Path):
     # Create logs directory if it doesn't exist
-    log_dir.mkdir(exist_ok=True)
-    log_file = log_dir / log_name
+    log_file.parent.mkdir(exist_ok=True, parents=True)
 
     log_config = {
         "version": 1,


### PR DESCRIPTION
I made the `log_util` use the env vars for configuring log file placement, and it seems to work as intended for me - I'm able to make the output fit with the experiment structure I'm looking for, by overwriting the defaults. The first commit follows the env vars on `main` currently, and the second commit cleans up this a bit; seems unnecessary to split the logic into `FILE_PATH` and `FILE_NAME`.