### PR TITLE
feat(oss-opensearch): Add memory-optimized search configuration option

### DIFF
--- a/vectordb_bench/backend/clients/oss_opensearch/config.py
+++ b/vectordb_bench/backend/clients/oss_opensearch/config.py
@@ -78,6 +78,7 @@ class OSSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
     quantization_type: OSSOpenSearchQuantization = OSSOpenSearchQuantization.fp32
     replication_type: str | None = "DOCUMENT"
     knn_derived_source_enabled: bool = False
+    memory_optimized_search: bool = False
 
     @root_validator
     def validate_engine_name(cls, values: dict):
@@ -105,6 +106,7 @@ class OSSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
             and self.quantization_type == obj.quantization_type
             and self.replication_type == obj.replication_type
             and self.knn_derived_source_enabled == obj.knn_derived_source_enabled
+            and self.memory_optimized_search == obj.memory_optimized_search
         )
 
     def __hash__(self) -> int:
@@ -120,6 +122,7 @@ class OSSOpenSearchIndexConfig(BaseModel, DBCaseConfig):
                 self.quantization_type,
                 self.replication_type,
                 self.knn_derived_source_enabled,
+                self.memory_optimized_search,
             )
         )
 

--- a/vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py
+++ b/vectordb_bench/backend/clients/oss_opensearch/oss_opensearch.py
@@ -32,6 +32,15 @@ VERSION_SPECIFIC_SETTING_RULES = [
         "applies": lambda version, _: version >= Version("3.0"),
         "value": lambda case_config: case_config.knn_derived_source_enabled,
     },
+    {
+        "name": "knn.memory_optimized_search",
+        "applies": lambda version, case_config: (
+            version >= Version("3.1")
+            and case_config.engine == OSSOS_Engine.faiss
+            and case_config.memory_optimized_search
+        ),
+        "value": lambda case_config: case_config.memory_optimized_search,
+    },
 ]
 
 
@@ -278,6 +287,7 @@ class OSSOpenSearch(VectorDB):
         log.info(f"Creating index with knn_derived_source_enabled: {self.case_config.knn_derived_source_enabled}")
         log.info(f"Creating index with engine: {self.case_config.engine}")
         log.info(f"Creating index with metric type: {self.case_config.metric_type_name}")
+        log.info(f"Creating index with memory_optimized_search: {self.case_config.memory_optimized_search}")
         log.info(f"All case_config parameters: {self.case_config.__dict__}")
 
         settings_manager = self._get_settings_manager(client)

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -1892,6 +1892,17 @@ CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch = CaseConfigInput(
     },
 )
 
+CaseConfigParamInput_MEMORY_OPTIMIZED_SEARCH_AWSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.memory_optimized_search,
+    displayLabel="Memory Optimized Search",
+    inputHelp="Enable memory-optimized search (OpenSearch 3.1+ and FAISS engine only).",
+    inputType=InputType.Bool,
+    inputConfig={
+        "value": False,
+    },
+    isDisplayed=lambda config: (config.get(CaseConfigParamType.engine_name, "").lower() == "faiss"),
+)
+
 MilvusLoadConfig = [
     CaseConfigParamInput_IndexType,
     CaseConfigParamInput_M,
@@ -2324,6 +2335,7 @@ AWSOpensearchLoadingConfig = [
     CaseConfigParamInput_NUMBER_OF_INDEXING_CLIENTS_AWSOpensearch,
     CaseConfigParamInput_INDEX_THREAD_QTY_AWSOpensearch,
     CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,
+    CaseConfigParamInput_MEMORY_OPTIMIZED_SEARCH_AWSOpensearch,
     CaseConfigParamInput_INDEX_THREAD_QTY_DURING_FORCE_MERGE_AWSOpensearch,
 ]
 
@@ -2340,6 +2352,7 @@ AWSOpenSearchPerformanceConfig = [
     CaseConfigParamInput_NUMBER_OF_INDEXING_CLIENTS_AWSOpensearch,
     CaseConfigParamInput_INDEX_THREAD_QTY_AWSOpensearch,
     CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,
+    CaseConfigParamInput_MEMORY_OPTIMIZED_SEARCH_AWSOpensearch,
     CaseConfigParamInput_INDEX_THREAD_QTY_DURING_FORCE_MERGE_AWSOpensearch,
 ]
 

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -128,6 +128,7 @@ class CaseConfigParamType(Enum):
     use_routing = "use_routing"
     replication_type = "replication_type"
     knn_derived_source_enabled = "knn_derived_source_enabled"
+    memory_optimized_search = "memory_optimized_search"
 
     # CockroachDB parameters
     min_partition_size = "min_partition_size"


### PR DESCRIPTION
## Summary
Adds support for memory-optimized search in OSS OpenSearch. This feature is available for OpenSearch 3.1+ with the FAISS engine.

## Changes

### Backend
- Added `memory_optimized_search` parameter to `OSSOpenSearchIndexConfig` class
- Implemented version-specific setting rule in `VERSION_SPECIFIC_SETTING_RULES` that automatically applies `knn.memory_optimized_search` setting when:
  - OpenSearch version >= 3.1
  - Engine is FAISS
  - `memory_optimized_search` is enabled

### Frontend
- Added `memory_optimized_search` to `CaseConfigParamType` enum
- Created `CaseConfigParamInput_MEMORY_OPTIMIZED_SEARCH_OSSOpensearch` UI input component
- Added the input to both `AWSOpensearchLoadingConfig` and `AWSOpenSearchPerformanceConfig` lists
- Input is conditionally displayed only when FAISS engine is selected

## Testing
- Verified setting is correctly applied to index settings (`knn.memory_optimized_search: true`)
- Confirmed conditional UI display based on engine type
- Tested with OpenSearch 3.1.0 and FAISS engine
- Validated that setting is only applied when all conditions are met
