### PR TITLE
feat(oss-opensearch): Add Disk-based vector search support

### DIFF
--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -1903,6 +1903,65 @@ CaseConfigParamInput_MEMORY_OPTIMIZED_SEARCH_AWSOpensearch = CaseConfigInput(
     isDisplayed=lambda config: (config.get(CaseConfigParamType.engine_name, "").lower() == "faiss"),
 )
 
+CaseConfigParamInput_ON_DISK_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.on_disk,
+    displayLabel="Disk-based Search",
+    inputHelp="Enable disk-based storage with Binary Quantization",
+    inputType=InputType.Bool,
+    inputConfig={
+        "value": False,
+    },
+)
+
+CaseConfigParamInput_COMPRESSION_LEVEL_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.compression_level,
+    displayLabel="Compression Level",
+    inputHelp="Binary quantization compression ratio for disk storage",
+    inputType=InputType.Option,
+    inputConfig={
+        "options": ["32x", "16x", "8x", "4x", "2x", "1x"],
+        "default": "32x",
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.on_disk, False) == True,
+)
+
+CaseConfigParamInput_OVERSAMPLE_FACTOR_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.oversample_factor,
+    displayLabel="Oversample Factor",
+    inputHelp="Rescoring oversample factor for two-phase search",
+    inputType=InputType.Float,
+    inputConfig={
+        "min": 1.0,
+        "max": 10.0,
+        "value": 3.0,
+        "step": 0.5,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.on_disk, False) == True,
+)
+
+CaseConfigParamInput_ENGINE_NAME_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.engine_name,
+    displayLabel="Engine",
+    inputHelp="HNSW algorithm implementation to use",
+    inputType=InputType.Option,
+    inputConfig={
+        "options": ["faiss", "lucene"],
+        "default": "faiss",
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.on_disk, False) == False,
+)
+
+CaseConfigParamInput_QUANTIZATION_TYPE_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.quantizationType,
+    displayLabel="Quantization Type",
+    inputHelp="Scalar quantization type for in-memory vectors",
+    inputType=InputType.Option,
+    inputConfig={
+        "options": ["fp32", "fp16"],
+        "default": "fp32",
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.on_disk, False) == False,
+)
 MilvusLoadConfig = [
     CaseConfigParamInput_IndexType,
     CaseConfigParamInput_M,
@@ -2356,6 +2415,45 @@ AWSOpenSearchPerformanceConfig = [
     CaseConfigParamInput_INDEX_THREAD_QTY_DURING_FORCE_MERGE_AWSOpensearch,
 ]
 
+
+OSSOpensearchLoadingConfig = [
+    CaseConfigParamInput_ON_DISK_OSSOpensearch,
+    CaseConfigParamInput_COMPRESSION_LEVEL_OSSOpensearch,
+    CaseConfigParamInput_ENGINE_NAME_OSSOpensearch,
+    CaseConfigParamInput_METRIC_TYPE_NAME_AWSOpensearch,
+    CaseConfigParamInput_M_AWSOpensearch,
+    CaseConfigParamInput_EFConstruction_AWSOpensearch,
+    CaseConfigParamInput_QUANTIZATION_TYPE_OSSOpensearch,
+    CaseConfigParamInput_REFRESH_INTERVAL_AWSOpensearch,
+    CaseConfigParamInput_NUMBER_OF_SHARDS_AWSOpensearch,
+    CaseConfigParamInput_NUMBER_OF_REPLICAS_AWSOpensearch,
+    CaseConfigParamInput_NUMBER_OF_INDEXING_CLIENTS_AWSOpensearch,
+    CaseConfigParamInput_INDEX_THREAD_QTY_AWSOpensearch,
+    CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,
+    CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch,
+    CaseConfigParamInput_MEMORY_OPTIMIZED_SEARCH_AWSOpensearch,
+]
+
+OSSOpenSearchPerformanceConfig = [
+    CaseConfigParamInput_ON_DISK_OSSOpensearch,
+    CaseConfigParamInput_COMPRESSION_LEVEL_OSSOpensearch,
+    CaseConfigParamInput_OVERSAMPLE_FACTOR_OSSOpensearch,
+    CaseConfigParamInput_EF_SEARCH_AWSOpensearch,
+    CaseConfigParamInput_ENGINE_NAME_OSSOpensearch,
+    CaseConfigParamInput_METRIC_TYPE_NAME_AWSOpensearch,
+    CaseConfigParamInput_M_AWSOpensearch,
+    CaseConfigParamInput_EFConstruction_AWSOpensearch,
+    CaseConfigParamInput_QUANTIZATION_TYPE_OSSOpensearch,
+    CaseConfigParamInput_REFRESH_INTERVAL_AWSOpensearch,
+    CaseConfigParamInput_NUMBER_OF_SHARDS_AWSOpensearch,
+    CaseConfigParamInput_NUMBER_OF_REPLICAS_AWSOpensearch,
+    CaseConfigParamInput_NUMBER_OF_INDEXING_CLIENTS_AWSOpensearch,
+    CaseConfigParamInput_INDEX_THREAD_QTY_AWSOpensearch,
+    CaseConfigParamInput_REPLICATION_TYPE_AWSOpensearch,
+    CaseConfigParamInput_KNN_DERIVED_SOURCE_ENABLED_AWSOpensearch,
+    CaseConfigParamInput_MEMORY_OPTIMIZED_SEARCH_AWSOpensearch,
+]
+
 # Map DB to config
 CASE_CONFIG_MAP = {
     DB.Milvus: {
@@ -2379,8 +2477,8 @@ CASE_CONFIG_MAP = {
         CaseLabel.Performance: AWSOpenSearchPerformanceConfig,
     },
     DB.OSSOpenSearch: {
-        CaseLabel.Load: AWSOpensearchLoadingConfig,
-        CaseLabel.Performance: AWSOpenSearchPerformanceConfig,
+        CaseLabel.Load: OSSOpensearchLoadingConfig,
+        CaseLabel.Performance: OSSOpenSearchPerformanceConfig,
     },
     DB.PgVector: {
         CaseLabel.Load: PgVectorLoadingConfig,

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -129,6 +129,9 @@ class CaseConfigParamType(Enum):
     replication_type = "replication_type"
     knn_derived_source_enabled = "knn_derived_source_enabled"
     memory_optimized_search = "memory_optimized_search"
+    on_disk = "on_disk"
+    compression_level = "compression_level"
+    oversample_factor = "oversample_factor"
 
     # CockroachDB parameters
     min_partition_size = "min_partition_size"


### PR DESCRIPTION
## Overview

Adds Disk-based vector search support for OSS OpenSearch (requires 2.17+).

## Features

- **Disk-based mode** with 6 compression levels (1x, 2x, 4x, 8x, 16x, 32x)
- **Auto engine selection** based on compression level (Lucene: 1x/4x, FAISS: 2x/8x/16x/32x)
- **Rescoring support** with configurable oversample factor
- **Conditional UI** - disk/in-memory options shown contextually
- **Version validation** - requires OpenSearch 2.17+

## Changes

### Backend (`config.py`, `oss_opensearch.py`)
- Added `on_disk`, `compression_level`, `oversample_factor` configuration
- Implemented `CompressionLevel` class with engine mapping
- Added `resolved_engine` property for automatic engine selection
- Extracted `_build_vector_field_mapping()` for disk vs in-memory modes
- Applied rescoring for both disk-based and in-memory quantization modes

### Frontend (`models.py`, `dbCaseConfigs.py`)
- Added 3 new enum types for disk-based parameters
- Created 5 OSS-specific UI inputs with conditional display logic
- Reused AWS inputs for common parameters (no duplication)

## Technical Notes

- **Mutual exclusivity**: Disk compression and in-memory quantization cannot coexist
- **Backward compatible**: Default `on_disk=False` preserves existing behavior
- **No AWS impact**: AWS OpenSearch configurations unchanged

## Screenshots
<img width="1543" height="861" alt="Screenshot 2025-12-24 at 01 39 24" src="https://github.com/user-attachments/assets/e82b92ad-9aa9-471a-acc6-5600826d301a" />
<img width="1550" height="868" alt="Screenshot 2025-12-24 at 01 39 47" src="https://github.com/user-attachments/assets/aa209c12-8ab4-4429-8da1-4401a69ddc5e" />
