### PR TITLE
feat(milvus): add SCANN index support

### DIFF
--- a/vectordb_bench/backend/clients/api.py
+++ b/vectordb_bench/backend/clients/api.py
@@ -41,6 +41,7 @@ class IndexType(str, Enum):
     GPU_IVF_PQ = "GPU_IVF_PQ"
     GPU_CAGRA = "GPU_CAGRA"
     SCANN = "scann"
+    SCANN_MILVUS = "SCANN_MILVUS"
     Hologres_HGraph = "HGraph"
     Hologres_Graph = "Graph"
     NONE = "NONE"

--- a/vectordb_bench/backend/clients/milvus/config.py
+++ b/vectordb_bench/backend/clients/milvus/config.py
@@ -414,6 +414,29 @@ class GPUCAGRAConfig(MilvusIndexConfig, DBCaseConfig):
         }
 
 
+class SCANNConfig(MilvusIndexConfig, DBCaseConfig):
+    nlist: int = 1024
+    with_raw_data: bool = False
+    reorder_k: int | None = 100
+    index: IndexType = IndexType.SCANN_MILVUS
+
+    def index_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "index_type": "SCANN",
+            "params": {
+                "nlist": self.nlist,
+                "with_raw_data": self.with_raw_data,
+            },
+        }
+
+    def search_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "params": {"reorder_k": self.reorder_k},
+        }
+
+
 _milvus_case_config = {
     IndexType.AUTOINDEX: AutoIndexConfig,
     IndexType.HNSW: HNSWConfig,
@@ -430,4 +453,5 @@ _milvus_case_config = {
     IndexType.GPU_IVF_PQ: GPUIVFPQConfig,
     IndexType.GPU_CAGRA: GPUCAGRAConfig,
     IndexType.GPU_BRUTE_FORCE: GPUBruteForceConfig,
+    IndexType.SCANN_MILVUS: SCANNConfig,
 }

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -411,6 +411,7 @@ CaseConfigParamInput_IndexType = CaseConfigInput(
             IndexType.IVFPQ.value,
             IndexType.IVFSQ8.value,
             IndexType.IVF_RABITQ.value,
+            IndexType.SCANN_MILVUS.value,
             IndexType.DISKANN.value,
             IndexType.Flat.value,
             IndexType.AUTOINDEX.value,
@@ -1014,10 +1015,31 @@ CaseConfigParamInput_Nlist = CaseConfigInput(
         IndexType.IVFPQ.value,
         IndexType.IVFSQ8.value,
         IndexType.IVF_RABITQ.value,
+        IndexType.SCANN_MILVUS.value,
         IndexType.GPU_IVF_FLAT.value,
         IndexType.GPU_IVF_PQ.value,
         IndexType.GPU_BRUTE_FORCE.value,
     ],
+)
+
+CaseConfigParamInput_with_raw_data = CaseConfigInput(
+    label=CaseConfigParamType.with_raw_data,
+    inputType=InputType.Option,
+    inputHelp="Whether to include raw data in the index. Setting to True enables reordering with original vectors.",
+    inputConfig={"options": [False, True]},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.SCANN_MILVUS.value,
+)
+
+CaseConfigParamInput_reorder_k = CaseConfigInput(
+    label=CaseConfigParamType.reorder_k,
+    inputType=InputType.Number,
+    inputHelp="Number of candidate vectors to reorder. Must be greater than or equal to k.",
+    inputConfig={
+        "min": 1,
+        "max": 65536,
+        "value": 100,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.SCANN_MILVUS.value,
 )
 
 CaseConfigParamInput_Nprobe = CaseConfigInput(
@@ -1908,6 +1930,7 @@ MilvusLoadConfig = [
     CaseConfigParamInput_M,
     CaseConfigParamInput_EFConstruction_Milvus,
     CaseConfigParamInput_Nlist,
+    CaseConfigParamInput_with_raw_data,
     CaseConfigParamInput_M_PQ,
     CaseConfigParamInput_Nbits_PQ,
     CaseConfigParamInput_intermediate_graph_degree,
@@ -1927,6 +1950,8 @@ MilvusPerformanceConfig = [
     CaseConfigParamInput_EF_Milvus,
     CaseConfigParamInput_SearchList,
     CaseConfigParamInput_Nlist,
+    CaseConfigParamInput_with_raw_data,
+    CaseConfigParamInput_reorder_k,
     CaseConfigParamInput_Nprobe,
     CaseConfigParamInput_M_PQ,
     CaseConfigParamInput_Nbits_PQ,

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -81,6 +81,8 @@ class CaseConfigParamType(Enum):
     refine_k = "refine_k"
     rbq_bits_query = "rbq_bits_query"
     sq_type = "sq_type"
+    with_raw_data = "with_raw_data"
+    reorder_k = "reorder_k"
     level = "level"
     maintenance_work_mem = "maintenance_work_mem"
     max_parallel_workers = "max_parallel_workers"


### PR DESCRIPTION
Issue: https://github.com/zilliztech/VectorDBBench/issues/681

- Add SCANN index type for Milvus
- Build params: nlist (default: 1024), with_raw_data (default: false)
- Search params: reorder_k (default: 100)
- Add UI configuration for SCANN index