### PR TITLE
feat(oss-opensearch): Add Scalar Quantization support

### DIFF
--- a/vectordb_bench/backend/clients/oss_opensearch/cli.py
+++ b/vectordb_bench/backend/clients/oss_opensearch/cli.py
@@ -100,9 +100,31 @@ class OSSOpenSearchTypedDict(TypedDict):
         str | None,
         click.option(
             "--quantization-type",
-            type=click.Choice(["fp32", "fp16"]),
+            type=click.Choice(["None", "LuceneSQ", "FaissSQfp16"]),
             help="quantization type for vectors (in index)",
-            default="fp32",
+            default="None",
+            required=False,
+        ),
+    ]
+
+    confidence_interval: Annotated[
+        float | None,
+        click.option(
+            "--confidence-interval",
+            type=float,
+            help="Confidence interval for Lucene SQ (0.0-1.0, optional)",
+            default=None,
+            required=False,
+        ),
+    ]
+
+    clip: Annotated[
+        bool,
+        click.option(
+            "--clip",
+            type=bool,
+            help="Clip vectors to [-65504, 65504] for FAISS FP16",
+            default=False,
             required=False,
         ),
     ]
@@ -150,6 +172,8 @@ def OSSOpenSearch(**parameters: Unpack[OSSOpenSearchHNSWTypedDict]):
             M=parameters["m"],
             engine=OSSOS_Engine(parameters["engine"]),
             quantization_type=OSSOpenSearchQuantization(parameters["quantization_type"]),
+            confidence_interval=parameters["confidence_interval"],
+            clip=parameters["clip"],
         ),
         **parameters,
     )

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -1973,17 +1973,65 @@ CaseConfigParamInput_ENGINE_NAME_OSSOpensearch = CaseConfigInput(
     isDisplayed=lambda config: config.get(CaseConfigParamType.on_disk, False) == False,
 )
 
-CaseConfigParamInput_QUANTIZATION_TYPE_OSSOpensearch = CaseConfigInput(
+CaseConfigParamInput_QUANTIZATION_TYPE_LUCENE_OSSOpensearch = CaseConfigInput(
     label=CaseConfigParamType.quantizationType,
     displayLabel="Quantization Type",
-    inputHelp="Scalar quantization type for in-memory vectors",
+    inputHelp="Scalar quantization for Lucene engine",
     inputType=InputType.Option,
     inputConfig={
-        "options": ["fp32", "fp16"],
-        "default": "fp32",
+        "options": ["None", "LuceneSQ"],
+        "default": "None",
     },
-    isDisplayed=lambda config: config.get(CaseConfigParamType.on_disk, False) == False,
+    isDisplayed=lambda config: (
+        not config.get(CaseConfigParamType.on_disk, False) and config.get(CaseConfigParamType.engine_name) == "lucene"
+    ),
 )
+
+CaseConfigParamInput_QUANTIZATION_TYPE_FAISS_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.quantizationType,
+    displayLabel="Quantization Type",
+    inputHelp="Scalar quantization for FAISS engine",
+    inputType=InputType.Option,
+    inputConfig={
+        "options": ["None", "FaissSQfp16"],
+        "default": "None",
+    },
+    isDisplayed=lambda config: (
+        not config.get(CaseConfigParamType.on_disk, False) and config.get(CaseConfigParamType.engine_name) == "faiss"
+    ),
+)
+
+CaseConfigParamInput_CONFIDENCE_INTERVAL_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.confidence_interval,
+    displayLabel="Confidence Interval",
+    inputHelp="Quantile range for Lucene SQ (0.9-1.0, 0 for dynamic, or empty for auto)",
+    inputType=InputType.Float,
+    inputConfig={
+        "min": 0.0,
+        "max": 1.0,
+        "value": None,
+        "step": 0.1,
+    },
+    isDisplayed=lambda config: (
+        not config.get(CaseConfigParamType.on_disk, False)
+        and config.get(CaseConfigParamType.quantizationType) == "LuceneSQ"
+    ),
+)
+
+CaseConfigParamInput_CLIP_OSSOpensearch = CaseConfigInput(
+    label=CaseConfigParamType.clip,
+    displayLabel="Clip Vectors",
+    inputHelp="Clip out-of-range values to [-65504, 65504] for FP16",
+    inputType=InputType.Bool,
+    inputConfig={
+        "value": False,
+    },
+    isDisplayed=lambda config: (
+        not config.get(CaseConfigParamType.on_disk, False)
+        and config.get(CaseConfigParamType.quantizationType) == "FaissSQfp16"
+    ),
+)
+
 MilvusLoadConfig = [
     CaseConfigParamInput_IndexType,
     CaseConfigParamInput_M,
@@ -2448,7 +2496,10 @@ OSSOpensearchLoadingConfig = [
     CaseConfigParamInput_METRIC_TYPE_NAME_AWSOpensearch,
     CaseConfigParamInput_M_AWSOpensearch,
     CaseConfigParamInput_EFConstruction_AWSOpensearch,
-    CaseConfigParamInput_QUANTIZATION_TYPE_OSSOpensearch,
+    CaseConfigParamInput_QUANTIZATION_TYPE_LUCENE_OSSOpensearch,
+    CaseConfigParamInput_QUANTIZATION_TYPE_FAISS_OSSOpensearch,
+    CaseConfigParamInput_CONFIDENCE_INTERVAL_OSSOpensearch,
+    CaseConfigParamInput_CLIP_OSSOpensearch,
     CaseConfigParamInput_REFRESH_INTERVAL_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_SHARDS_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_REPLICAS_AWSOpensearch,
@@ -2468,7 +2519,10 @@ OSSOpenSearchPerformanceConfig = [
     CaseConfigParamInput_METRIC_TYPE_NAME_AWSOpensearch,
     CaseConfigParamInput_M_AWSOpensearch,
     CaseConfigParamInput_EFConstruction_AWSOpensearch,
-    CaseConfigParamInput_QUANTIZATION_TYPE_OSSOpensearch,
+    CaseConfigParamInput_QUANTIZATION_TYPE_LUCENE_OSSOpensearch,
+    CaseConfigParamInput_QUANTIZATION_TYPE_FAISS_OSSOpensearch,
+    CaseConfigParamInput_CONFIDENCE_INTERVAL_OSSOpensearch,
+    CaseConfigParamInput_CLIP_OSSOpensearch,
     CaseConfigParamInput_REFRESH_INTERVAL_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_SHARDS_AWSOpensearch,
     CaseConfigParamInput_NUMBER_OF_REPLICAS_AWSOpensearch,

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -134,6 +134,8 @@ class CaseConfigParamType(Enum):
     on_disk = "on_disk"
     compression_level = "compression_level"
     oversample_factor = "oversample_factor"
+    confidence_interval = "confidence_interval"
+    clip = "clip"
 
     # CockroachDB parameters
     min_partition_size = "min_partition_size"


### PR DESCRIPTION
## Summary
Adds support for Lucene Scalar Quantization (SQ) and FAISS 16-bit Scalar Quantization (FP16) for OSS OpenSearch, enabling users to reduce memory usage for in-memory vector indexes.

## Changes

### Backend
- **Refactored quantization enum**: `fp32/fp16` → `None/LuceneSQ/FaissSQfp16`
- **Added new fields**:
  - `confidence_interval` (float, optional): For Lucene SQ quantile calculation
  - `clip` (bool, optional): For FAISS FP16 out-of-range value handling
- **Implemented validator**: Converts UI/CLI string values to enum with backward compatibility
- **Updated encoder logic**: Engine-aware configuration for Lucene SQ and FAISS FP16

### Frontend
- **Engine-aware UI**: Separate quantization dropdowns for Lucene and FAISS engines
  - Lucene: `["None", "LuceneSQ"]`
  - FAISS: `["None", "FaissSQfp16"]`
- **Progressive disclosure**: Optional parameters appear only when relevant
  - `confidence_interval` shown for Lucene SQ
  - `clip` shown for FAISS FP16
- **Prevents invalid combinations**: UI logic ensures engine/quantization compatibility

### CLI
- **Updated options**: `--quantization-type` now accepts `None`, `LuceneSQ`, `FaissSQfp16`
- **New parameters**: `--confidence-interval` and `--clip` for fine-tuning

## Technical Details

### Lucene SQ
- Converts 32-bit float vectors to 7-bit integers (4x memory reduction)
- Optional `confidence_interval` (0.0-1.0) controls quantile calculation
- OpenSearch API: `encoder: {name: "sq", parameters: {confidence_interval: <value>}}`

### FAISS FP16
- Converts 32-bit float vectors to 16-bit floats (2x memory reduction)
- Optional `clip` parameter handles out-of-range values ([-65504, 65504])
- OpenSearch API: `encoder: {name: "sq", parameters: {type: "fp16", clip: true}}`

## Testing
- ✅ All linter checks passed
- ✅ Backward compatible with existing configs
- ✅ Engine-aware UI prevents invalid configurations
- ✅ CLI and UI both functional

## Screenshots
<img width="1367" height="910" alt="Screenshot 2025-12-24 at 16 46 01" src="https://github.com/user-attachments/assets/f91d6b06-e4ce-442f-abe2-5ac62259dcf4" />
<img width="1355" height="907" alt="Screenshot 2025-12-24 at 16 46 21" src="https://github.com/user-attachments/assets/2e66b8f1-5855-4ef4-9218-828c038546a5" />

