### PR TITLE
fix: update logging messages to reflect correct vector counts in Qdrant

### DIFF
--- a/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
+++ b/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
@@ -93,7 +93,7 @@ class QdrantCloud(VectorDB):
                     continue
                 if info.status == CollectionStatus.GREEN:
                     msg = (
-                        f"Stored vectors: {info.vectors_count}, Indexed vectors: {info.indexed_vectors_count}, "
+                        f"Stored vectors: {info.points_count}, Indexed vectors: {info.indexed_vectors_count}, "
                         f"Collection status: {info.status}, Segment counts: {info.segments_count}"
                     )
                     log.info(msg)

--- a/vectordb_bench/backend/clients/qdrant_local/qdrant_local.py
+++ b/vectordb_bench/backend/clients/qdrant_local/qdrant_local.py
@@ -139,14 +139,14 @@ class QdrantLocal(VectorDB):
                 if info.status == CollectionStatus.GREEN:
                     log.info(f"Finishing building index for collection: {self.collection_name}")
                     msg = (
-                        f"Stored vectors: {info.vectors_count}, Indexed vectors: {info.indexed_vectors_count}, "
-                        f"Collection status: {info.indexed_vectors_count}"
+                        f"Stored vectors: {info.points_count}, Indexed vectors: {info.indexed_vectors_count}, "
+                        f"Collection status: {info.status}"
                     )
                     log.info(msg)
                     return
 
         except Exception as e:
-            log.warning(f"QdrantCloud ready to search error: {e}")
+            log.warning(f"QdrantLocal ready to search error: {e}")
             raise e from None
 
     def insert_embeddings(


### PR DESCRIPTION
In the newest qdrant client,there has no "vectors_count" in the response of "get_collection".It is replaced by "points_count".