### PR TITLE
fix: Fix benchmark results display for paswordless AWS OpenSearch benchmarks

### DIFF
--- a/tests/test_aws_opensearch_cli.py
+++ b/tests/test_aws_opensearch_cli.py
@@ -1,0 +1,61 @@
+import pytest
+from pydantic import SecretStr
+
+from vectordb_bench.backend.clients.aws_opensearch.cli import optional_secret_str
+
+
+class TestOptionalSecretStr:
+    """Test cases for the optional_secret_str helper function."""
+
+    def test_none_input_returns_none(self):
+        """Test that None input returns None."""
+        result = optional_secret_str(None)
+        assert result is None
+
+    def test_string_input_returns_secret_str(self):
+        """Test that string input returns SecretStr."""
+        test_password = "my_secret_password"
+        result = optional_secret_str(test_password)
+
+        assert isinstance(result, SecretStr)
+        assert result.get_secret_value() == test_password
+
+    def test_empty_string_returns_secret_str(self):
+        """Test that empty string returns SecretStr with empty value."""
+        result = optional_secret_str("")
+
+        assert isinstance(result, SecretStr)
+        assert result.get_secret_value() == ""
+
+    @pytest.mark.parametrize("test_input,expected_value", [
+        ("password123", "password123"),
+        ("", ""),
+        ("special!@#$%^&*()chars", "special!@#$%^&*()chars"),
+        ("   spaces   ", "   spaces   "),
+        ("unicode_ñáéíóú", "unicode_ñáéíóú"),
+    ])
+    def test_various_string_inputs(self, test_input, expected_value):
+        """Test various string inputs return SecretStr with correct values."""
+        result = optional_secret_str(test_input)
+
+        assert isinstance(result, SecretStr)
+        assert result.get_secret_value() == expected_value
+
+    def test_none_vs_empty_string_difference(self):
+        """Test that None and empty string are handled differently."""
+        none_result = optional_secret_str(None)
+        empty_result = optional_secret_str("")
+
+        assert none_result is None
+        assert isinstance(empty_result, SecretStr)
+        assert empty_result.get_secret_value() == ""
+
+    def test_return_type_annotations(self):
+        """Test that return types match the function signature."""
+        # Test None case
+        none_result = optional_secret_str(None)
+        assert none_result is None
+
+        # Test string case
+        string_result = optional_secret_str("test")
+        assert isinstance(string_result, SecretStr)

--- a/vectordb_bench/backend/clients/aws_opensearch/cli.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/cli.py
@@ -17,11 +17,16 @@ from .config import AWSOS_Engine, AWSOSQuantization
 log = logging.getLogger(__name__)
 
 
+def optional_secret_str(value: str | None) -> SecretStr | None:
+    """Convert string to SecretStr, handling None gracefully."""
+    return None if value is None else SecretStr(value)
+
+
 class AWSOpenSearchTypedDict(TypedDict):
     host: Annotated[str, click.option("--host", type=str, help="Db host", required=True)]
     port: Annotated[int, click.option("--port", type=int, default=80, help="Db Port")]
-    user: Annotated[str, click.option("--user", type=str, help="Db User")]
-    password: Annotated[str, click.option("--password", type=str, help="Db password")]
+    user: Annotated[str | None, click.option("--user", type=str, help="Db User")]
+    password: Annotated[str | None, click.option("--password", type=str, help="Db password")]
     number_of_shards: Annotated[
         int,
         click.option("--number-of-shards", type=int, help="Number of primary shards for the index", default=1),
@@ -188,7 +193,7 @@ def AWSOpenSearch(**parameters: Unpack[AWSOpenSearchHNSWTypedDict]):
             host=parameters["host"],
             port=parameters["port"],
             user=parameters["user"],
-            password=SecretStr(parameters["password"]),
+            password=optional_secret_str(parameters["password"]),
         ),
         db_case_config=AWSOpenSearchIndexConfig(
             number_of_shards=parameters["number_of_shards"],


### PR DESCRIPTION

Fixes https://github.com/zilliztech/VectorDBBench/issues/716

Description:
When running a benchmark against AWS OpenSearch, username and password are optional and can we left empty so benchmark can use AWS authentiction tokens in environment variables. This works perfectly, and benchamrk runs and does the expected inserts and queries on the AWS OS cluster. But when trying to look at the benchmark results, http://localhost:8502/results displays this error:
```
 pydantic.error_wrappers.ValidationError: 2 validation errors for AWSOpenSearchConfig user Empty string! (type=value_error) password Empty string!
  (type=value_error)

  File "/Users/jvegas/.cache/uv/archive-v0/DcT73OzatkvN3UXwJBtH_/lib/python3.12/site-packages/vectordb_bench/frontend/pages/results.py", line 62, in <module>
      main()
  File "/Users/jvegas/.cache/uv/archive-v0/DcT73OzatkvN3UXwJBtH_/lib/python3.12/site-packages/vectordb_bench/frontend/pages/results.py", line 29, in main
      allResults = benchmark_runner.get_results()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jvegas/.cache/uv/archive-v0/DcT73OzatkvN3UXwJBtH_/lib/python3.12/site-packages/vectordb_bench/interface.py", line 106, in get_results
      return ResultCollector.collect(target_dir)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jvegas/.cache/uv/archive-v0/DcT73OzatkvN3UXwJBtH_/lib/python3.12/site-packages/vectordb_bench/backend/result_collector.py", line 18, in
  collect
      file_result = TestResult.read_file(json_file, trans_unit=True)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jvegas/.cache/uv/archive-v0/DcT73OzatkvN3UXwJBtH_/lib/python3.12/site-packages/vectordb_bench/models.py", line 331, in read_file
      task_config["db_config"] = db.config_cls(**task_config["db_config"])
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pydantic/main.py", line 364, in pydantic.main.BaseModel.__init__
```
Looks like during results loading the system is applying a more strict validation that does not allow empty username or password, which was allowed at test creation. This PR fixes validation to allow for empty username or password in both cases, resulting in viewables results for passwordless AWS OS benchmarks

Before:

<img width="2270" height="1644" alt="545455322-c00d9c2d-1e4e-43db-957a-9b04b8cf727e" src="https://github.com/user-attachments/assets/a0c92e07-7b5c-4b5f-8e6e-9975022ebef0" />

After:

<img width="2396" height="1730" alt="Screenshot 2026-02-06 at 16 15 34" src="https://github.com/user-attachments/assets/6a565bcf-d9ec-4449-975e-4232f08c0979" />

