### PR TITLE
Feat: Add label filter support in pgdiskann client

### DIFF
--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -82,35 +82,6 @@ class PgDiskANN(VectorDB):
         self.cursor = None
         self.conn = None
 
-    def get_size_info(self):
-        try:
-            assert self.conn is not None, "Connection is not initialized"
-            assert self.cursor is not None, "Cursor is not initialized"
-            log.info(f"{self.name} client get size info.")
-
-            size_sql = sql.SQL(
-                "SELECT pg_size_pretty(pg_table_size('{table_name}')) as table_size, pg_size_pretty(pg_table_size('{index_name}')) as index_size;"
-            ).format(
-                table_name=sql.Identifier(self.table_name),
-                index_name=sql.Identifier(self._index_name),
-            )
-            log.debug(size_sql.as_string(self.cursor))
-            self.cursor.execute(size_sql)
-            self.conn.commit()
-            result = self.cursor.fetchone()
-
-            if result:
-                table_size = result[0]
-                index_size = result[1]
-                log.info(f"Table Size: {table_size}, Index Size: {index_size}")
-                return (table_size, index_size)
-            else:
-                log.error("No results returned from the query.")
-                return (0, 0)
-        except Exception as e:
-            log.warning("Failed to fetch table and index information")
-            return (0, 0)
-
     @staticmethod
     def _create_connection(**kwargs) -> tuple[Connection, Cursor]:
         conn = psycopg.connect(**kwargs)

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -48,6 +48,8 @@ class PgDiskANN(VectorDB):
         self.table_name = collection_name
         self.dim = dim
         self.with_scalar_labels = with_scalar_labels
+        # Table column for scalar labels (standard naming convention across all database clients).
+        # Note: Dataset uses "labels" (plural), table uses "label" (singular).
         self._scalar_label_field = "label"
         self.where_clause = ""
 
@@ -312,6 +314,7 @@ class PgDiskANN(VectorDB):
                     ),
                 )
 
+            # Disable TOAST compression on the vector column to improve query performance.
             self.cursor.execute(
                 sql.SQL("ALTER TABLE public.{table_name} ALTER COLUMN embedding SET STORAGE PLAIN;").format(
                     table_name=sql.Identifier(self.table_name)

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -48,8 +48,6 @@ class PgDiskANN(VectorDB):
         self.table_name = collection_name
         self.dim = dim
         self.with_scalar_labels = with_scalar_labels
-        # Table column for scalar labels (standard naming convention across all database clients).
-        # Note: Dataset uses "labels" (plural), table uses "label" (singular).
         self._scalar_label_field = "label"
         self.where_clause = ""
 
@@ -314,7 +312,6 @@ class PgDiskANN(VectorDB):
                     ),
                 )
 
-            # Disable TOAST compression on the vector column to improve query performance.
             self.cursor.execute(
                 sql.SQL("ALTER TABLE public.{table_name} ALTER COLUMN embedding SET STORAGE PLAIN;").format(
                     table_name=sql.Identifier(self.table_name)

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -11,6 +11,7 @@ from pgvector.psycopg import register_vector
 from psycopg import Connection, Cursor, sql
 
 from vectordb_bench.backend.filter import Filter, FilterOp
+
 from ..api import VectorDB
 from .config import PgDiskANNConfigDict, PgDiskANNIndexConfig
 
@@ -290,7 +291,7 @@ class PgDiskANN(VectorDB):
             if self.with_scalar_labels:
                 self.cursor.execute(
                     sql.SQL("""
-                        CREATE TABLE IF NOT EXISTS public.{table_name} 
+                        CREATE TABLE IF NOT EXISTS public.{table_name}
                         ({primary_field} BIGINT PRIMARY KEY, embedding vector({dim}), {label_field} VARCHAR(64));
                         """).format(
                         table_name=sql.Identifier(self.table_name),
@@ -302,7 +303,7 @@ class PgDiskANN(VectorDB):
             else:
                 self.cursor.execute(
                     sql.SQL("""
-                        CREATE TABLE IF NOT EXISTS public.{table_name} 
+                        CREATE TABLE IF NOT EXISTS public.{table_name}
                         ({primary_field} BIGINT PRIMARY KEY, embedding vector({dim}));
                         """).format(
                         table_name=sql.Identifier(self.table_name),

--- a/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
+++ b/vectordb_bench/backend/clients/pgdiskann/pgdiskann.py
@@ -29,7 +29,7 @@ class PgDiskANN(VectorDB):
     conn: psycopg.Connection[Any] | None = None
     cursor: psycopg.Cursor[Any] | None = None
 
-    _search: sql.Composed  
+    _search: sql.Composed
 
     def __init__(
         self,
@@ -48,7 +48,7 @@ class PgDiskANN(VectorDB):
         self.dim = dim
         self.with_scalar_labels = with_scalar_labels
         self._scalar_label_field = "label"
-        self.where_clause = "" 
+        self.where_clause = ""
 
         self._index_name = "pgdiskann_index"
         self._primary_field = "id"
@@ -101,8 +101,7 @@ class PgDiskANN(VectorDB):
         search_params = self.case_config.search_param()
 
         if search_params.get("reranking"):
-            search_query = sql.SQL(
-                """
+            search_query = sql.SQL("""
                 SELECT i.id
                 FROM (
                     SELECT id, embedding
@@ -113,8 +112,7 @@ class PgDiskANN(VectorDB):
                 ) i
                 ORDER BY i.embedding {reranking_metric_fun_op} %s::vector
                 LIMIT %s::int
-                """
-            ).format(
+                """).format(
                 table_name=sql.Identifier(self.table_name),
                 where_clause=sql.SQL(self.where_clause),
                 metric_fun_op=sql.SQL(search_params["metric_fun_op"]),
@@ -124,9 +122,7 @@ class PgDiskANN(VectorDB):
         else:
             search_query = sql.Composed(
                 [
-                    sql.SQL(
-                        "SELECT id FROM public.{table_name} {where_clause} ORDER BY embedding "
-                    ).format(
+                    sql.SQL("SELECT id FROM public.{table_name} {where_clause} ORDER BY embedding ").format(
                         table_name=sql.Identifier(self.table_name),
                         where_clause=sql.SQL(self.where_clause),
                     ),
@@ -268,18 +264,12 @@ class PgDiskANN(VectorDB):
                     ),
                 )
 
-        with_clause = (
-            sql.SQL("WITH ({});").format(sql.SQL(", ").join(options))
-            if any(options)
-            else sql.Composed(())
-        )
+        with_clause = sql.SQL("WITH ({});").format(sql.SQL(", ").join(options)) if any(options) else sql.Composed(())
 
-        index_create_sql = sql.SQL(
-            """
+        index_create_sql = sql.SQL("""
             CREATE INDEX IF NOT EXISTS {index_name} ON public.{table_name}
             USING {index_type} (embedding {embedding_metric})
-            """
-        ).format(
+            """).format(
             index_name=sql.Identifier(self._index_name),
             table_name=sql.Identifier(self.table_name),
             index_type=sql.Identifier(index_param["index_type"].lower()),
@@ -299,12 +289,10 @@ class PgDiskANN(VectorDB):
 
             if self.with_scalar_labels:
                 self.cursor.execute(
-                    sql.SQL(
-                        """
+                    sql.SQL("""
                         CREATE TABLE IF NOT EXISTS public.{table_name} 
                         ({primary_field} BIGINT PRIMARY KEY, embedding vector({dim}), {label_field} VARCHAR(64));
-                        """
-                    ).format(
+                        """).format(
                         table_name=sql.Identifier(self.table_name),
                         dim=dim,
                         primary_field=sql.Identifier(self._primary_field),
@@ -313,12 +301,10 @@ class PgDiskANN(VectorDB):
                 )
             else:
                 self.cursor.execute(
-                    sql.SQL(
-                        """
+                    sql.SQL("""
                         CREATE TABLE IF NOT EXISTS public.{table_name} 
                         ({primary_field} BIGINT PRIMARY KEY, embedding vector({dim}));
-                        """
-                    ).format(
+                        """).format(
                         table_name=sql.Identifier(self.table_name),
                         dim=dim,
                         primary_field=sql.Identifier(self._primary_field),
@@ -326,11 +312,11 @@ class PgDiskANN(VectorDB):
                 )
 
             self.cursor.execute(
-                sql.SQL(
-                    "ALTER TABLE public.{table_name} ALTER COLUMN embedding SET STORAGE PLAIN;"
-                ).format(table_name=sql.Identifier(self.table_name)),
+                sql.SQL("ALTER TABLE public.{table_name} ALTER COLUMN embedding SET STORAGE PLAIN;").format(
+                    table_name=sql.Identifier(self.table_name)
+                ),
             )
-            
+
             self.conn.commit()
         except Exception as e:
             log.warning(f"Failed to create pgdiskann table: {self.table_name} error: {e}")
@@ -347,9 +333,7 @@ class PgDiskANN(VectorDB):
         assert self.cursor is not None, "Cursor is not initialized"
 
         if self.with_scalar_labels:
-            assert (
-                labels_data is not None
-            ), "labels_data should be provided if with_scalar_labels is set to True"
+            assert labels_data is not None, "labels_data should be provided if with_scalar_labels is set to True"
 
         try:
             metadata_arr = np.array(metadata)
@@ -405,13 +389,12 @@ class PgDiskANN(VectorDB):
 
         search_params = self.case_config.search_param()
         q = np.asarray(query)
-        
+
         result = self.cursor.execute(
             self._search,
             (q, q, k) if search_params.get("reranking", False) else (q, k),
             prepare=True,
             binary=True,
         )
-        
-        return [int(i[0]) for i in result.fetchall()]
 
+        return [int(i[0]) for i in result.fetchall()]


### PR DESCRIPTION
This PR adds support for label-based filtering in pgdiskann client.

Changes introduced:

- Added support for FilterOp.StrEqual to enable filtering by scalar string labels.
- Introduced optional with_scalar_labels flag to create tables with an additional label column.
- Updated table creation logic to conditionally include scalar label support.
- Extended insert_embeddings to handle label data when enabled.
- Implemented prepare_filter() to dynamically construct the WHERE clause based on filter type.
- Unified search query generation through _generate_search_query() to support filtered and unfiltered search paths.
- Existing numeric filtering (id >= value) and non-filtered search behavior remain unchanged.
- Includes vector storage optimization (`SET STORAGE PLAIN`) to disable TOAST compression on the embedding column for improved query performance

<img width="1858" height="1003" alt="Screenshot from 2026-02-13 11-53-39" src="https://github.com/user-attachments/assets/dcf35af8-3b43-43ac-99c4-26bc17977a37" />
