### PR TITLE
fix(qdrant) : pass timeout parameter to query_points in Qdrant clients

### DIFF
--- a/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
+++ b/vectordb_bench/backend/clients/qdrant_cloud/qdrant_cloud.py
@@ -205,6 +205,7 @@ class QdrantCloud(VectorDB):
             query_filter=self.query_filter,
             search_params=self.db_case_config.search_param(),
             with_payload=self.db_case_config.with_payload,
+            timeout=timeout,
         )
 
         res = points_res.points

--- a/vectordb_bench/backend/clients/qdrant_local/qdrant_local.py
+++ b/vectordb_bench/backend/clients/qdrant_local/qdrant_local.py
@@ -227,6 +227,7 @@ class QdrantLocal(VectorDB):
             limit=k,
             query_filter=f,
             search_params=SearchParams(**self.search_parameter),
+            timeout=timeout,
         ).points
 
         return [result.id for result in res]


### PR DESCRIPTION
### fix: pass timeout parameter to query_points in Qdrant clients

The search_embedding method in both qdrant clients (cloud and local) accepted a timeout parameter but didn't pass it to the underlying query_points call. This fix ensures the timeout is properly propagated

without the fix : when you call the search_embeddings( .. , timeout= 20) the timeout is ignored and it always uses default timeout (None) 
with the fix : the timeout you specify is actually used (control how long to wait for searches ) 