### PR TITLE
fix(pgvector): normalize index_type to lowercase in _create_index to …

### DIFF
--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -383,8 +383,8 @@ class PgVector(VectorDB):
             ).format(
                 index_name=sql.Identifier(self._index_name),
                 table_name=sql.Identifier(self.table_name),
+                # [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
                 index_type=sql.Identifier(index_type_lower),
-                [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
                 # index_type=sql.Identifier(index_param["index_type"]),
                 embedding_metric=sql.Identifier(index_param["metric"]),
             )

--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -366,7 +366,7 @@ class PgVector(VectorDB):
                     if index_param["quantization_type"] == "bit"
                     else sql.Identifier("embedding")
                 ),
-                [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
+                # [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
                 index_type=sql.Identifier(index_type_lower),
                 # index_type=sql.Identifier(index_param["index_type"]),
                 # This assumes that the quantization_type value matches the quantization function name

--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -335,6 +335,12 @@ class PgVector(VectorDB):
 
         index_param = self.case_config.index_param()
         self._set_parallel_index_build_param()
+        # [FIX] The index access method name registered by the PostgreSQL pgvector extension is in lowercase (e.g., "hnsw", "ivfflat"),
+        # but the index type passed from the frontend UI is uppercase "HNSW" via IndexType.HNSW.value, causing SQL syntax "USING 'HNSW'"
+        # to fail with error "access method HNSW does not exist". Here we uniformly convert it to lowercase to match PostgreSQL's access method name.
+        index_type_lower = index_param["index_type"].lower()
+        log.info(f"index_type (original={index_param['index_type']}, normalized={index_type_lower})")
+        
         options = []
         for option in index_param["index_creation_with_options"]:
             if option["val"] is not None:
@@ -360,7 +366,9 @@ class PgVector(VectorDB):
                     if index_param["quantization_type"] == "bit"
                     else sql.Identifier("embedding")
                 ),
-                index_type=sql.Identifier(index_param["index_type"]),
+                [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
+                index_type=sql.Identifier(index_type_lower),
+                # index_type=sql.Identifier(index_param["index_type"]),
                 # This assumes that the quantization_type value matches the quantization function name
                 quantization_type=sql.SQL(index_param["quantization_type"]),
                 dim=self.dim,
@@ -375,7 +383,9 @@ class PgVector(VectorDB):
             ).format(
                 index_name=sql.Identifier(self._index_name),
                 table_name=sql.Identifier(self.table_name),
-                index_type=sql.Identifier(index_param["index_type"]),
+                index_type=sql.Identifier(index_type_lower),
+                [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
+                # index_type=sql.Identifier(index_param["index_type"]),
                 embedding_metric=sql.Identifier(index_param["metric"]),
             )
 


### PR DESCRIPTION
…match PostgreSQL access method names

PostgreSQL pgvector extension registers index access methods in lowercase (e.g. "hnsw", "ivfflat"), but the frontend passes IndexType.HNSW.value which is uppercase "HNSW", causing "access method HNSW does not exist" error.