### PR TITLE
fix: support self-hosted Elasticsearch via --host/--port in elasticcloud commands

### DIFF
--- a/vectordb_bench/backend/clients/elastic_cloud/cli.py
+++ b/vectordb_bench/backend/clients/elastic_cloud/cli.py
@@ -17,11 +17,60 @@ DBTYPE = DB.ElasticCloud
 class ElasticCloudTypedDict(TypedDict):
     cloud_id: Annotated[
         str,
-        click.option("--cloud-id", type=str, help="Elastic Cloud ID", required=True),
+        click.option(
+            "--cloud-id",
+            type=str,
+            help="Elastic Cloud ID. Omit when connecting to a self-hosted ES via --host.",
+            required=False,
+            default="",
+        ),
+    ]
+    scheme: Annotated[
+        str,
+        click.option(
+            "--scheme",
+            type=click.Choice(["http", "https"], case_sensitive=False),
+            help="Scheme for host-based connection.",
+            required=False,
+            default="https",
+            show_default=True,
+        ),
+    ]
+    host: Annotated[
+        str,
+        click.option(
+            "--host",
+            type=str,
+            help="Elasticsearch host (for self-hosted ES; alternative to --cloud-id).",
+            required=False,
+            default="",
+        ),
+    ]
+    port: Annotated[
+        int,
+        click.option(
+            "--port",
+            type=int,
+            help="Elasticsearch port (for host-based connection).",
+            required=False,
+            default=9200,
+            show_default=True,
+        ),
+    ]
+    user: Annotated[
+        str,
+        click.option(
+            "--user",
+            type=str,
+            help="Elasticsearch user.",
+            required=False,
+            default="elastic",
+            show_default=True,
+        ),
     ]
     password: Annotated[
         str,
-        click.option("--password", type=str, help="Elastic Cloud password", required=True),
+        click.option("--password", type=str, help="Elasticsearch password", required=True),
     ]
     number_of_shards: Annotated[
         int,
@@ -170,7 +219,11 @@ def ElasticCloudHNSW(**parameters: Unpack[ElasticCloudHNSWTypedDict]):
         db=DBTYPE,
         db_config=ElasticCloudConfig(
             db_label=parameters["db_label"],
-            cloud_id=SecretStr(parameters["cloud_id"]),
+            cloud_id=SecretStr(parameters["cloud_id"]) if parameters["cloud_id"] else None,
+            scheme=parameters["scheme"],
+            host=parameters["host"],
+            port=parameters["port"],
+            user=parameters["user"],
             password=SecretStr(parameters["password"]),
         ),
         db_case_config=ElasticCloudIndexConfig(
@@ -202,7 +255,11 @@ def ElasticCloudHNSWInt8(**parameters: Unpack[ElasticCloudHNSWTypedDict]):
         db=DBTYPE,
         db_config=ElasticCloudConfig(
             db_label=parameters["db_label"],
-            cloud_id=SecretStr(parameters["cloud_id"]),
+            cloud_id=SecretStr(parameters["cloud_id"]) if parameters["cloud_id"] else None,
+            scheme=parameters["scheme"],
+            host=parameters["host"],
+            port=parameters["port"],
+            user=parameters["user"],
             password=SecretStr(parameters["password"]),
         ),
         db_case_config=ElasticCloudIndexConfig(
@@ -234,7 +291,11 @@ def ElasticCloudHNSWInt4(**parameters: Unpack[ElasticCloudHNSWTypedDict]):
         db=DBTYPE,
         db_config=ElasticCloudConfig(
             db_label=parameters["db_label"],
-            cloud_id=SecretStr(parameters["cloud_id"]),
+            cloud_id=SecretStr(parameters["cloud_id"]) if parameters["cloud_id"] else None,
+            scheme=parameters["scheme"],
+            host=parameters["host"],
+            port=parameters["port"],
+            user=parameters["user"],
             password=SecretStr(parameters["password"]),
         ),
         db_case_config=ElasticCloudIndexConfig(
@@ -266,7 +327,11 @@ def ElasticCloudHNSWBBQ(**parameters: Unpack[ElasticCloudHNSWTypedDict]):
         db=DBTYPE,
         db_config=ElasticCloudConfig(
             db_label=parameters["db_label"],
-            cloud_id=SecretStr(parameters["cloud_id"]),
+            cloud_id=SecretStr(parameters["cloud_id"]) if parameters["cloud_id"] else None,
+            scheme=parameters["scheme"],
+            host=parameters["host"],
+            port=parameters["port"],
+            user=parameters["user"],
             password=SecretStr(parameters["password"]),
         ),
         db_case_config=ElasticCloudIndexConfig(

--- a/vectordb_bench/backend/clients/elastic_cloud/config.py
+++ b/vectordb_bench/backend/clients/elastic_cloud/config.py
@@ -1,18 +1,56 @@
 from enum import StrEnum
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, SecretStr, model_validator
 
 from ..api import DBCaseConfig, DBConfig, IndexType, MetricType
 
 
 class ElasticCloudConfig(DBConfig, BaseModel):
-    cloud_id: SecretStr
+    # Elastic Cloud connection. Takes precedence when set.
+    cloud_id: SecretStr | None = None
+    # Self-hosted / host-based connection (used when cloud_id is not provided).
+    scheme: str = "https"
+    host: str = ""
+    port: int = 9200
+    user: str = "elastic"
     password: SecretStr
 
+    @model_validator(mode="before")
+    @classmethod
+    def not_empty_field(cls, data: any) -> any:
+        if not isinstance(data, dict):
+            return data
+        skip = (
+            set(cls.common_short_configs())
+            | set(cls.common_long_configs())
+            | {"cloud_id", "host"}
+        )
+        for field_name, v in data.items():
+            if field_name in skip:
+                continue
+            if isinstance(v, str) and not v:
+                msg = "Empty string!"
+                raise ValueError(msg)
+        return data
+
+    @model_validator(mode="after")
+    def _check_connection_target(self) -> "ElasticCloudConfig":
+        has_cloud_id = bool(self.cloud_id and self.cloud_id.get_secret_value())
+        if not has_cloud_id and not self.host:
+            msg = "ElasticCloudConfig requires either cloud_id or host to be set."
+            raise ValueError(msg)
+        return self
+
     def to_dict(self) -> dict:
+        auth = (self.user, self.password.get_secret_value())
+        if self.cloud_id and self.cloud_id.get_secret_value():
+            return {
+                "cloud_id": self.cloud_id.get_secret_value(),
+                "basic_auth": auth,
+            }
         return {
-            "cloud_id": self.cloud_id.get_secret_value(),
-            "basic_auth": ("elastic", self.password.get_secret_value()),
+            "hosts": [{"scheme": self.scheme, "host": self.host, "port": self.port}],
+            "basic_auth": auth,
         }
 
 

--- a/vectordb_bench/backend/clients/elastic_cloud/config.py
+++ b/vectordb_bench/backend/clients/elastic_cloud/config.py
@@ -20,11 +20,7 @@ class ElasticCloudConfig(DBConfig, BaseModel):
     def not_empty_field(cls, data: any) -> any:
         if not isinstance(data, dict):
             return data
-        skip = (
-            set(cls.common_short_configs())
-            | set(cls.common_long_configs())
-            | {"cloud_id", "host"}
-        )
+        skip = set(cls.common_short_configs()) | set(cls.common_long_configs()) | {"cloud_id", "host"}
         for field_name, v in data.items():
             if field_name in skip:
                 continue


### PR DESCRIPTION
## Summary

- Extend `ElasticCloudConfig` to accept either `cloud_id` **or** a self-hosted connection (`scheme` / `host` / `port` / `user`).
- Add `--host / --port / --scheme / --user` flags (and make `--cloud-id` optional) on all four `elasticcloudhnsw*` subcommands.
- Existing `--cloud-id` based usage is unchanged — `cloud_id` still takes precedence when both are supplied.

## Motivation (#758)

Users running stock Elasticsearch 8.x (self-hosted, on-prem, or Tencent/Aliyun-hosted stock ES) had no working VectorDBBench entrypoint:

- `elasticcloudhnsw*` required `--cloud-id` — no way to point at a host/port.
- `tencentelasticsearch` accepts `--host/--port` but hardcodes `index_options.type = "vsearch"` (Tencent-specific), which stock ES rejects with `Unknown vector index options type [vsearch] for field [vector]`.

With this change, the correct mapping (`hnsw`, `int8_hnsw`, `int4_hnsw`, `bbq_hnsw`) can finally be used against self-hosted ES clusters:

```bash
vectordbbench elasticcloudhnsw \
  --scheme http --host rw-xxxxx --port 9204 \
  --user elastic --password 'pw' \
  --case-type Performance768D1M --m 16 --ef-construction 200 --k 10
```

## Test plan

- [x] `elasticcloudhnsw --cloud-id ... --password ... --dry-run` — builds `{"cloud_id": ..., "basic_auth": (...)}` (backward compatible).
- [x] `elasticcloudhnsw --host rw-test --port 9204 --scheme http --password ... --dry-run` — builds `{"hosts": [{...}], "basic_auth": (...)}`.
- [x] `elasticcloudhnsw --password ... --dry-run` (neither flag) — rejected with `ElasticCloudConfig requires either cloud_id or host to be set.`
- [x] `ruff check vectordb_bench/backend/clients/elastic_cloud/` — passes.
- [ ] Manual run against a real self-hosted Elasticsearch 8.x cluster (requires reporter env).

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)