### PR TITLE
Fix: Use sql.SQL() for pgvector access method names to fix "HNSW does not exist" error

### DIFF
--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -360,7 +360,7 @@ class PgVector(VectorDB):
                     if index_param["quantization_type"] == "bit"
                     else sql.Identifier("embedding")
                 ),
-                index_type=sql.Identifier(index_param["index_type"]),
+                index_type=sql.SQL(index_param["index_type"]),
                 # This assumes that the quantization_type value matches the quantization function name
                 quantization_type=sql.SQL(index_param["quantization_type"]),
                 dim=self.dim,
@@ -375,7 +375,7 @@ class PgVector(VectorDB):
             ).format(
                 index_name=sql.Identifier(self._index_name),
                 table_name=sql.Identifier(self.table_name),
-                index_type=sql.Identifier(index_param["index_type"]),
+                index_type=sql.SQL(index_param["index_type"]),
                 embedding_metric=sql.Identifier(index_param["metric"]),
             )
 


### PR DESCRIPTION
## Problem
PGVector HNSW index creation fails with:
- "access method 'HNSW' does not exist"

This happens through the WebUI but works via CLI.

## Root Cause
In `pgvector.py` lines 363 and 378, the index_type is wrapped with `sql.Identifier()`, which PostgreSQL treats as a quoted identifier. PostgreSQL access methods must NOT be quoted.

## Solution
Changed `sql.Identifier(index_param["index_type"])` to `sql.SQL(index_param["index_type"])`

This generates proper SQL:
- Before: `USING "hnsw"` ❌
- After: `USING hnsw` ✅

## Fixes
Closes #759