### PR TITLE
Fix: Map "ivf_flat" to "ivfflat" for pgvector index access method

### DIFF
--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -335,9 +335,11 @@ class PgVector(VectorDB):
 
         index_param = self.case_config.index_param()
         self._set_parallel_index_build_param()
-        # [FIX] The index access method name registered by the PostgreSQL pgvector extension is in lowercase (e.g., "hnsw", "ivfflat"),
-        # but the index type passed from the frontend UI is uppercase "HNSW" via IndexType.HNSW.value, causing SQL syntax "USING 'HNSW'"
-        # to fail with error "access method HNSW does not exist". Here we uniformly convert it to lowercase to match PostgreSQL's access method name.
+        # [FIX] The index access method name registered by the PostgreSQL pgvector extension is in
+        # lowercase (e.g., "hnsw", "ivfflat"), but the index type passed from the frontend UI is
+        # uppercase "HNSW" via IndexType.HNSW.value, causing SQL syntax "USING 'HNSW'" to fail
+        # with error "access method HNSW does not exist". Here we uniformly convert it to lowercase
+        # to match PostgreSQL's access method name.
         index_type_lower = index_param["index_type"].lower()
         # [FIX] The pgvector access method name is "ivfflat" (no underscore), but IndexType.IVFFlat.value
         # produces "IVF_FLAT" which becomes "ivf_flat" after lowercase conversion, causing SQL syntax
@@ -346,7 +348,7 @@ class PgVector(VectorDB):
         if index_type_lower == "ivf_flat":
             index_type_lower = "ivfflat"
         log.info(f"index_type (original={index_param['index_type']}, normalized={index_type_lower})")
-        
+
         options = []
         for option in index_param["index_creation_with_options"]:
             if option["val"] is not None:
@@ -374,7 +376,6 @@ class PgVector(VectorDB):
                 ),
                 # [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
                 index_type=sql.Identifier(index_type_lower),
-                # index_type=sql.Identifier(index_param["index_type"]),
                 # This assumes that the quantization_type value matches the quantization function name
                 quantization_type=sql.SQL(index_param["quantization_type"]),
                 dim=self.dim,
@@ -391,7 +392,6 @@ class PgVector(VectorDB):
                 table_name=sql.Identifier(self.table_name),
                 # [FIX] Use lowercase index_type_lower instead of original index_param["index_type"]
                 index_type=sql.Identifier(index_type_lower),
-                # index_type=sql.Identifier(index_param["index_type"]),
                 embedding_metric=sql.Identifier(index_param["metric"]),
             )
 

--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -339,6 +339,12 @@ class PgVector(VectorDB):
         # but the index type passed from the frontend UI is uppercase "HNSW" via IndexType.HNSW.value, causing SQL syntax "USING 'HNSW'"
         # to fail with error "access method HNSW does not exist". Here we uniformly convert it to lowercase to match PostgreSQL's access method name.
         index_type_lower = index_param["index_type"].lower()
+        # [FIX] The pgvector access method name is "ivfflat" (no underscore), but IndexType.IVFFlat.value
+        # produces "IVF_FLAT" which becomes "ivf_flat" after lowercase conversion, causing SQL syntax
+        # "USING 'ivf_flat'" to fail with error "access method 'ivf_flat' does not exist".
+        # Here we map "ivf_flat" → "ivfflat" to match PostgreSQL pgvector's registered access method name.
+        if index_type_lower == "ivf_flat":
+            index_type_lower = "ivfflat"
         log.info(f"index_type (original={index_param['index_type']}, normalized={index_type_lower})")
         
         options = []


### PR DESCRIPTION
- IndexType.IVFFlat.value="IVF_FLAT" → .lower()="ivf_flat" caused SQL to fail with "access method 'ivf_flat' does not exist"
- pgvector PostgreSQL extension expects "ivfflat" (no underscore), not "ivf_flat"
- Added explicit mapping after lowercase normalization: if index_type_lower == "ivf_flat": index_type_lower = "ivfflat"

## Problem
PGVector IVFFlat index creation fails via UI with:
- ERROR: access method "ivf_flat" does not exist

But works fine via CLI.

## Root Cause
The frontend config sends the wrong IndexType values:
- Sends `IndexType.IVFFlat.value` = "IVF_FLAT" instead of "ivfflat"

pgvector PostgreSQL extension expects "ivfflat" (no underscore), not "ivf_flat"

## Solution
```python
if index_type_lower == "ivf_flat":
    index_type_lower = "ivfflat"  # [FIX] pgvector expects "ivfflat" not "ivf_flat"
```

**Before:** `"IVF_FLAT"` → `"ivf_flat"` → **ERROR**
**After:**  `"IVF_FLAT"` → `"ivf_flat"` → `"ivfflat"` → ✅ `CREATE INDEX USING ivfflat`

## Evidence
**UI logs (broken):**
<img width="1849" height="336" alt="Screenshot from 2026-04-20 16-14-45" src="https://github.com/user-attachments/assets/17c20a39-6f93-40a1-96bd-58ea0939b065" />

