### PR TITLE
feat(loader): cap default insert workers to min(cpu, 4)

### DIFF
--- a/vectordb_bench/backend/runner/concurrent_runner.py
+++ b/vectordb_bench/backend/runner/concurrent_runner.py
@@ -51,7 +51,7 @@ class ConcurrentInsertRunner:
         normalize: Whether to L2-normalize embeddings.
         filters: Filter configuration.
         timeout: Timeout in seconds for the overall operation.
-        max_workers: Number of concurrent workers (default: cpu_count).
+        max_workers: Number of concurrent workers (default: min(cpu_count, 4)).
         backend: Executor backend to use ('threading' or 'async').
     """
 
@@ -72,7 +72,7 @@ class ConcurrentInsertRunner:
         self.filters = filters
         self.backend = backend
 
-        effective_workers = max_workers or mp.cpu_count()
+        effective_workers = max_workers or min(mp.cpu_count(), 4)
         if not db.thread_safe:
             log.info(f"DB {db.name} is not thread-safe, falling back to max_workers=1")
             effective_workers = 1


### PR DESCRIPTION
ConcurrentInsertRunner previously defaulted to mp.cpu_count(),
spawning one worker per CPU when load_concurrency was unset.
On high-core hosts this opens many parallel client connections,
saturating modest DBs / network paths and yielding worse
load throughput than a smaller, steadier worker count.

Cap the unset default to min(cpu_count, 4). Explicit
load_concurrency from CLI / config / submitTask still wins.