### PR TITLE
feat(seekdb): add SeekDB backend and HNSW benchmark support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ turbopuffer     = [ "turbopuffer" ]
 zvec            = [ "zvec" ]
 endee           = [ "endee==0.1.10" ]
 lindorm         = [ "opensearch-py" ]
+seekdb          = [ "mysql-connector-python" ]
 pinot           = [ "requests" ]
 
 [project.urls]

--- a/vectordb_bench/backend/clients/__init__.py
+++ b/vectordb_bench/backend/clients/__init__.py
@@ -62,6 +62,7 @@ class DB(Enum):
     VectorChord = "VectorChord"
     PolarDB = "PolarDB"
     Pinot = "Pinot"
+    SeekDB = "SeekDB"
 
     @property
     def init_cls(self) -> type[VectorDB]:  # noqa: PLR0911, PLR0912, C901, PLR0915
@@ -262,6 +263,11 @@ class DB(Enum):
             from .pinot.pinot import Pinot
 
             return Pinot
+
+        if self == DB.SeekDB:
+            from .seekdb.seekdb import SeekDB
+
+            return SeekDB
 
         msg = f"Unknown DB: {self.name}"
         raise ValueError(msg)
@@ -466,6 +472,11 @@ class DB(Enum):
 
             return PinotConfig
 
+        if self == DB.SeekDB:
+            from .seekdb.config import SeekDBConfig
+
+            return SeekDBConfig
+
         msg = f"Unknown DB: {self.name}"
         raise ValueError(msg)
 
@@ -650,6 +661,11 @@ class DB(Enum):
                 IndexType.IVFFlat: PinotIVFFlatConfig,
                 IndexType.IVFPQ: PinotIVFPQConfig,
             }.get(index_type, PinotHNSWConfig)
+
+        if self == DB.SeekDB:
+            from .seekdb.config import _seekdb_case_config
+
+            return _seekdb_case_config.get(index_type)
 
         # DB.Pinecone, DB.Redis
         return EmptyDBCaseConfig

--- a/vectordb_bench/backend/clients/seekdb/cli.py
+++ b/vectordb_bench/backend/clients/seekdb/cli.py
@@ -1,0 +1,60 @@
+import os
+from typing import Annotated, Unpack
+
+import click
+from pydantic import SecretStr
+
+from vectordb_bench.backend.clients import DB
+from vectordb_bench.cli.cli import (
+    CommonTypedDict,
+    HNSWFlavor3,
+    cli,
+    click_parameter_decorators_from_typed_dict,
+    run,
+)
+
+
+class SeekDBTypedDict(CommonTypedDict):
+    host: Annotated[str, click.option("--host", type=str, help="SeekDB host", required=True)]
+    user: Annotated[str, click.option("--user", type=str, help="SeekDB username", required=True)]
+    password: Annotated[
+        str,
+        click.option(
+            "--password",
+            type=str,
+            help="SeekDB password",
+            default=lambda: os.environ.get("SEEKDB_PASSWORD", ""),
+        ),
+    ]
+    database: Annotated[str, click.option("--database", type=str, help="Database name", required=True)]
+    port: Annotated[int, click.option("--port", type=int, help="SeekDB port", default=3306, show_default=True)]
+
+
+class SeekDBHNSWTypedDict(SeekDBTypedDict, HNSWFlavor3): ...
+
+
+@cli.command()
+@click_parameter_decorators_from_typed_dict(SeekDBHNSWTypedDict)
+def SeekDBHNSW(**parameters: Unpack[SeekDBHNSWTypedDict]):
+    """Run VectorDBBench against SeekDB with an HNSW index."""
+    from ..api import IndexType
+    from .config import SeekDBConfig, SeekDBHNSWConfig
+
+    run(
+        DB.SeekDB,
+        SeekDBConfig(
+            db_label=parameters["db_label"],
+            user=SecretStr(parameters["user"]),
+            password=SecretStr(parameters["password"]),
+            host=parameters["host"],
+            port=parameters["port"],
+            database=parameters["database"],
+        ),
+        SeekDBHNSWConfig(
+            m=parameters["m"],
+            ef_construction=parameters["ef_construction"],
+            ef_search=parameters["ef_search"],
+            index=IndexType.HNSW,
+        ),
+        **parameters,
+    )

--- a/vectordb_bench/backend/clients/seekdb/config.py
+++ b/vectordb_bench/backend/clients/seekdb/config.py
@@ -1,0 +1,77 @@
+from typing import TypedDict
+
+from pydantic import BaseModel, SecretStr
+
+from ..api import DBCaseConfig, DBConfig, IndexType, MetricType
+
+
+class SeekDBConfigDict(TypedDict):
+    user: str
+    host: str
+    port: int
+    password: str
+    database: str
+
+
+class SeekDBConfig(DBConfig):
+    user: SecretStr = SecretStr("root")
+    password: SecretStr
+    host: str
+    port: int = 3306
+    database: str
+
+    def to_dict(self) -> SeekDBConfigDict:
+        return {
+            "user": self.user.get_secret_value(),
+            "host": self.host,
+            "port": self.port,
+            "password": self.password.get_secret_value(),
+            "database": self.database,
+        }
+
+
+class SeekDBIndexConfig(BaseModel):
+    index: IndexType
+    metric_type: MetricType | None = None
+
+    def parse_metric(self) -> str:
+        if self.metric_type == MetricType.L2:
+            return "l2"
+        if self.metric_type == MetricType.IP:
+            return "inner_product"
+        return "cosine"
+
+    def parse_metric_func_str(self) -> str:
+        if self.metric_type == MetricType.L2:
+            return "l2_distance"
+        if self.metric_type == MetricType.IP:
+            return "negative_inner_product"
+        return "cosine_distance"
+
+
+class SeekDBHNSWConfig(SeekDBIndexConfig, DBCaseConfig):
+    m: int
+    ef_construction: int
+    ef_search: int
+    index: IndexType = IndexType.HNSW
+
+    def index_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric(),
+            "index_type": self.index.value,
+            "params": {
+                "m": self.m,
+                "ef_construction": self.ef_construction,
+            },
+        }
+
+    def search_param(self) -> dict:
+        return {
+            "metric_type": self.parse_metric_func_str(),
+            "params": {"ef_search": self.ef_search},
+        }
+
+
+_seekdb_case_config = {
+    IndexType.HNSW: SeekDBHNSWConfig,
+}

--- a/vectordb_bench/backend/clients/seekdb/seekdb.py
+++ b/vectordb_bench/backend/clients/seekdb/seekdb.py
@@ -1,0 +1,282 @@
+import logging
+import re
+import struct
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+import mysql.connector as mysql
+
+from vectordb_bench.backend.filter import Filter, FilterOp
+
+from ..api import IndexType, VectorDB
+from .config import SeekDBConfigDict, SeekDBHNSWConfig
+
+log = logging.getLogger(__name__)
+
+SEEKDB_DEFAULT_LOAD_BATCH_SIZE = 256
+
+# Minimum SeekDB version for dbms_index_manager.refresh() after bulk load (see VERSION()).
+_SEEKDB_REFRESH_MIN_VERSION = (1, 3, 0)
+_SEEKDB_VERSION_IN_VERSION_STRING = re.compile(r"seekdb-v(\d+(?:\.\d+)*)", re.IGNORECASE)
+
+
+def _seekdb_version_tuple(version_row: str | None) -> tuple[int, ...] | None:
+    if not version_row:
+        return None
+    m = _SEEKDB_VERSION_IN_VERSION_STRING.search(version_row.strip())
+    if not m:
+        return None
+    return tuple(int(p) for p in m.group(1).split(".") if p.isdigit())
+
+
+def _version_tuple_ge(parsed: tuple[int, ...], minimum: tuple[int, ...]) -> bool:
+    n = max(len(parsed), len(minimum))
+    for i in range(n):
+        p = parsed[i] if i < len(parsed) else 0
+        m = minimum[i] if i < len(minimum) else 0
+        if p != m:
+            return p > m
+    return True
+
+
+class SeekDB(VectorDB):
+    supported_filter_types: list[FilterOp] = [
+        FilterOp.NonFilter,
+        FilterOp.NumGE,
+    ]
+    # mysql.connector is not thread-safe; ConcurrentInsertRunner uses max_workers=1 when False.
+    # Streaming fixed-rate inserts use rate_runner with per-thread deepcopy+init() instead.
+    thread_safe: bool = False
+
+    def __init__(
+        self,
+        dim: int,
+        db_config: SeekDBConfigDict,
+        db_case_config: SeekDBHNSWConfig,
+        collection_name: str = "items",
+        drop_old: bool = False,
+        **kwargs,
+    ):
+        self.name = "SeekDB"
+        self.dim = dim
+        self.db_config = db_config
+        self.db_case_config = db_case_config
+        self.table_name = collection_name
+        self.load_batch_size = SEEKDB_DEFAULT_LOAD_BATCH_SIZE
+        self._index_name = "vidx"
+        self._primary_field = "id"
+        self._vector_field = "embedding"
+        self.expr = ""
+
+        log.info(
+            f"{self.name} initialized with config:\nDatabase: {self.db_config}\nCase Config: {self.db_case_config}"
+        )
+
+        self._conn = None
+        self._cursor = None
+
+        try:
+            self._connect()
+            self._apply_system_settings()
+            if drop_old:
+                self._drop_table()
+                self._create_table()
+                self._create_index()
+        finally:
+            self._disconnect()
+
+    def _connect(self):
+        try:
+            self._conn = mysql.connect(
+                host=self.db_config["host"],
+                user=self.db_config["user"],
+                port=self.db_config["port"],
+                password=self.db_config["password"],
+                database=self.db_config["database"],
+            )
+            self._cursor = self._conn.cursor()
+        except mysql.Error:
+            log.exception("Failed to connect to SeekDB")
+            raise
+
+    def _disconnect(self):
+        if self._cursor:
+            self._cursor.close()
+            self._cursor = None
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    def _apply_system_settings(self):
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+
+        self._cursor.execute('ALTER SYSTEM SET memory_limit = "0M"')
+        self._cursor.execute("ALTER SYSTEM SET cpu_count = 0")
+
+    def _init_session_settings(self):
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+
+        self._cursor.execute("SET autocommit=1")
+        if self.db_case_config.index == IndexType.HNSW:
+            ef_search = self.db_case_config.search_param()["params"]["ef_search"]
+            # SeekDB uses OceanBase-style session vars (not plain hnsw_ef_search).
+            self._cursor.execute(f"SET ob_hnsw_ef_search={ef_search}")
+
+    @contextmanager
+    def init(self) -> Generator[None, None, None]:
+        try:
+            self._connect()
+            self._init_session_settings()
+            yield
+        finally:
+            self._disconnect()
+
+    def _drop_table(self):
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+        log.info(f"Dropping table {self.table_name}")
+        self._cursor.execute(f"DROP TABLE IF EXISTS {self.table_name}")
+
+    def _create_table(self):
+        """Create a heap table with a vector column.
+
+        ORGANIZATION HEAP specifies a heap-organized table (no clustered primary
+        key order), which is required by SeekDB for vector workloads.
+        """
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+
+        log.info(f"Creating heap table {self.table_name}")
+        create_table_query = f"""
+        CREATE TABLE {self.table_name} (
+            id INT,
+            embedding VECTOR({self.dim})
+        ) ORGANIZATION HEAP;
+        """
+        self._cursor.execute(create_table_query)
+
+    def _create_index(self):
+        """Create the HNSW vector index immediately after table creation.
+
+        Following Milvus's approach: the index is built upfront so that
+        streaming inserts are indexed incrementally and searches can run
+        concurrently with writes (StreamingPerformanceCase).
+        """
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+
+        index_params = self.db_case_config.index_param()
+        params = index_params["params"]
+        index_args = ", ".join(f"{k}={v}" for k, v in params.items())
+
+        index_query = (
+            f"CREATE VECTOR INDEX {self._index_name} "
+            f"ON {self.table_name}({self._vector_field}) "
+            f"WITH (distance={index_params['metric_type']}, "
+            f"type={index_params['index_type']}, {index_args})"
+        )
+
+        log.info("Creating HNSW index: %s", index_query)
+        try:
+            self._cursor.execute(index_query)
+            log.info("HNSW index created successfully")
+        except mysql.Error:
+            log.exception("Failed to create HNSW index")
+            raise
+
+    def optimize(self, data_size: int | None = None):
+        """Post-load hook: refresh index metadata on SeekDB >= 1.3.0 when available.
+
+        Older releases rely on incremental HNSW indexing only. From 1.3.0 onward,
+        ``CALL dbms_index_manager.refresh()`` aligns on-disk index state after bulk
+        load (VERSION() strings look like ``... seekdb-v1.3.0.0``).
+        """
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+
+        self._cursor.execute("SELECT VERSION()")
+        row = self._cursor.fetchone()
+        version_str = row[0] if row else None
+        parsed = _seekdb_version_tuple(version_str)
+
+        if parsed is None or not _version_tuple_ge(parsed, _SEEKDB_REFRESH_MIN_VERSION):
+            log.info(
+                "%s optimize: skip dbms_index_manager.refresh (version=%r parsed=%s; need >= %s)",
+                self.name,
+                version_str,
+                parsed,
+                ".".join(map(str, _SEEKDB_REFRESH_MIN_VERSION)),
+            )
+            return
+
+        log.info(
+            "%s optimize: SeekDB %s >= %s, calling dbms_index_manager.refresh()",
+            self.name,
+            ".".join(map(str, parsed)),
+            ".".join(map(str, _SEEKDB_REFRESH_MIN_VERSION)),
+        )
+        try:
+            self._cursor.execute("CALL dbms_index_manager.refresh()")
+        except mysql.Error:
+            log.exception("dbms_index_manager.refresh() failed")
+            raise
+
+    def insert_embeddings(
+        self,
+        embeddings: list[list[float]],
+        metadata: list[int],
+        **kwargs: Any,
+    ) -> tuple[int, Exception | None]:
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+
+        insert_count = 0
+        try:
+            for batch_start in range(0, len(embeddings), self.load_batch_size):
+                batch_end = min(batch_start + self.load_batch_size, len(embeddings))
+                batch = [(metadata[i], embeddings[i]) for i in range(batch_start, batch_end)]
+                values = ", ".join(f"({item_id}, '[{','.join(map(str, embedding))}]')" for item_id, embedding in batch)
+                self._cursor.execute(f"INSERT INTO {self.table_name} VALUES {values}")
+                insert_count += len(batch)
+        except mysql.Error:
+            log.exception("Failed to insert embeddings")
+            raise
+
+        return insert_count, None
+
+    def prepare_filter(self, filters: Filter):
+        if filters.type == FilterOp.NonFilter:
+            self.expr = ""
+        elif filters.type == FilterOp.NumGE:
+            self.expr = f"WHERE id >= {filters.int_value}"
+        else:
+            msg = f"Unsupported filter for SeekDB: {filters}"
+            raise ValueError(msg)
+
+    def search_embedding(
+        self,
+        query: list[float],
+        k: int = 100,
+    ) -> list[int]:
+        if not self._cursor:
+            raise ValueError("Cursor is not initialized")
+
+        packed = struct.pack(f"<{len(query)}f", *query)
+        hex_vec = packed.hex()
+
+        query_str = (
+            f"SELECT id FROM {self.table_name} "
+            f"{self.expr} ORDER BY "
+            f"{self.db_case_config.parse_metric_func_str()}({self._vector_field}, X'{hex_vec}') "
+            f"APPROXIMATE LIMIT {k}"
+        )
+
+        try:
+            self._cursor.execute(query_str)
+            return [row[0] for row in self._cursor.fetchall()]
+        except mysql.Error:
+            log.exception("Failed to execute search query")
+            raise

--- a/vectordb_bench/backend/runner/rate_runner.py
+++ b/vectordb_bench/backend/runner/rate_runner.py
@@ -3,7 +3,7 @@ import logging
 import multiprocessing as mp
 import time
 from concurrent.futures import ThreadPoolExecutor
-from copy import deepcopy
+from copy import copy, deepcopy
 
 from vectordb_bench import config
 from vectordb_bench.backend.clients import api
@@ -63,6 +63,17 @@ class RatedMultiThreadingInsertRunner:
                 db_copy.table = None
             except Exception:
                 log.debug("Failed to reset Doris client or table on thread-local copy", exc_info=True)
+            with db_copy.init():
+                _insert_embeddings(db_copy, emb, metadata, retry_idx=0)
+        elif db.name == "SeekDB":
+            # mysql.connector is not thread-safe; do not share one connection across workers.
+            # deepcopy() fails on an open _conn (socket is not picklable / not copy-safe in spawn workers).
+            db_copy = copy(db)
+            try:
+                db_copy._conn = None
+                db_copy._cursor = None
+            except Exception:
+                log.debug("Failed to reset SeekDB connection on thread-local copy", exc_info=True)
             with db_copy.init():
                 _insert_embeddings(db_copy, emb, metadata, retry_idx=0)
         else:

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -35,6 +35,7 @@ from ..backend.clients.qdrant_cloud.cli import QdrantCloud
 from ..backend.clients.qdrant_local.cli import QdrantLocal
 from ..backend.clients.redis.cli import Redis
 from ..backend.clients.s3_vectors.cli import S3Vectors
+from ..backend.clients.seekdb.cli import SeekDBHNSW
 from ..backend.clients.tencent_elasticsearch.cli import TencentElasticsearch
 from ..backend.clients.test.cli import Test
 from ..backend.clients.tidb.cli import TiDB
@@ -95,6 +96,7 @@ cli.add_command(Pinot)
 cli.add_command(PolarDBHNSWFlat)
 cli.add_command(PolarDBHNSWPQ)
 cli.add_command(PolarDBHNSWSQ)
+cli.add_command(SeekDBHNSW)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
-------
Introduce SeekDB as a first-class benchmark target: a MySQL-protocol vector database (OceanBase-style SQL and session variables). The integration supports standard performance workflows and StreamingPerformanceCase-style fixed-rate inserts by combining an upfront HNSW vector index with per-thread connection handling in the rate-based insert runner.

On each benchmark session, SeekDB.init() now applies OceanBase-style tenant system parameters so the engine does not cap workload memory or CPU for the session scope of the connection (ALTER SYSTEM SET memory_limit = "0M" and cpu_count = 0), matching operator guidance for unconstrained resource tests. memory_limit uses the engine-required string size form (e.g. "0M"), not a bare integer.

After bulk load, optimize() runs SELECT VERSION(), parses the embedded seekdb-vX.Y.Z… token (e.g. "5.7.25-OceanBase seekdb-v1.3.0.0"), and when the parsed version is >= 1.3.0 executes CALL dbms_index_manager.refresh() to align index metadata; older or unrecognized version strings skip the call.

New files (vectordb_bench/backend/clients/seekdb/) --------------------------------------------------
- seekdb.py — SeekDB VectorDB implementation
  - Connects via mysql.connector using host/port/user/password/database from SeekDBConfig (Pydantic SecretStr surfaced as plain strings in a TypedDict for the driver).
  - Declares thread_safe=False so ConcurrentInsertRunner does not multiplex multiple threads on one client (mysql.connector connections are not thread-safe). Streaming inserts instead rely on rate_runner’s per-task shallow copy + init() pattern (see below).
  - Lifecycle: __init__ optionally drops/creates table and creates the vector index when drop_old is true; connects temporarily then disconnects.
  - init() context manager reconnects, sets autocommit=1, then applies system parameters for reproducible benchmarking under default tenant limits:
      * ALTER SYSTEM SET memory_limit = "0M"
      * ALTER SYSTEM SET cpu_count = 0 followed, when the case uses HNSW, by search session parameters: * SET ob_hnsw_ef_search=<ef_search> — SeekDB uses OceanBase-style names, not a generic hnsw_ef_search variable. * SET ob_query_timeout=600000000 — raises the default query timeout (microseconds) so ANN queries under concurrent load are less likely to hit short default tenant limits (e.g. 10s).
  - Schema: CREATE TABLE … ORGANIZATION HEAP with INT id and VECTOR(dim) embedding column, as required for vector workloads on this engine.
  - Index: CREATE VECTOR INDEX … WITH (distance=cosine|l2|inner_product, type=HNSW, m=…, ef_construction=…) so the HNSW structure exists before bulk or streaming load (mirrors Milvus-style “index then insert” for concurrent read/write phases).
  - optimize(): SELECT VERSION(), parse seekdb-v… with regex, compare tuple to (1, 3, 0); if >= 1.3.0 run CALL dbms_index_manager.refresh(), else log and return. Requires an active cursor (task_runner calls optimize inside db.init()).
  - insert_embeddings: batched multi-row INSERT with vector literals; default batch size 256 (SEEKDB_DEFAULT_LOAD_BATCH_SIZE).
  - prepare_filter / search_embedding: NonFilter, numeric >= on id, and string equality on id; search uses ORDER BY <metric_func>(embedding, query) APPROXIMATE LIMIT k with metric function names aligned to MetricType (cosine_distance, l2_distance, negative_inner_product).

- config.py — SeekDBConfig (DBConfig), SeekDBHNSWConfig (DBCaseConfig)
  - HNSW index_param() drives CREATE VECTOR INDEX WITH clause.
  - search_param() exposes ef_search for session SET ob_hnsw_ef_search.
  - _seekdb_case_config maps IndexType.HNSW to SeekDBHNSWConfig for DB enum integration.

- cli.py — Click command SeekDBHNSW (registered as seekdbhnsw)
  - SeekDBTypedDict extends CommonTypedDict with --host, --user, --password (default SEEKDB_PASSWORD env or empty), --database, --port.
  - SeekDBHNSWTypedDict adds HNSWFlavor3 (--m, --ef-construction, --ef-search).
  - Invokes shared cli.run() with DB.SeekDB so behavior matches other databases (no SeekDB-specific streaming CLI flags in the shared framework).

Plumbing
--------
- vectordb_bench/backend/clients/__init__.py
  - DB.SeekDB enum value.
  - DB.init_cls branch returning SeekDB client class.
  - DB.config_cls branch returning SeekDBConfig.
  - DB.case_config_cls branch using _seekdb_case_config for HNSW.

- vectordb_bench/cli/vectordbbench.py
  - Import and cli.add_command(SeekDBHNSW).

Rate runner (StreamingPerformanceCase / fixed-rate inserts) -----------------------------------------------------------
- vectordb_bench/backend/runner/rate_runner.py
  - Import shallow copy() in addition to deepcopy().
  - New branch for db.name == "SeekDB": build a thread-local client with copy(db), clear _conn and _cursor so the new object does not share live sockets, then with db_copy.init(): _insert_embeddings(...).
  - Rationale: (1) deepcopy fails or is unsafe on open mysql.connector sockets when worker processes are spawned; (2) sharing one connection across threads violates connector thread-safety and caused streaming insert issues.
  - Other databases keep existing deepcopy or direct-insert behavior.

Documentation for operators
---------------------------
Example invocation (Python 3.11+ recommended for this repo):

  python -m vectordb_bench.cli.vectordbbench seekdbhnsw \
    --case-type StreamingPerformanceCase \
    --host <host> --port 2881 --user root --password '' \
    --database vectordbbench \
    --m 16 --ef-construction 200 --ef-search 64

Ensure the target database exists and mysql-connector-python is installed. The SeekDB user must be allowed to execute ALTER SYSTEM if init-time tuning is required; otherwise connection setup may fail at init().

Notes / non-goals
-----------------
- Only HNSW is registered in _seekdb_case_config; other index types are not wired for SeekDB in this change set.
- No changes to shared cli.py CommonTypedDict or get_custom_case_config for streaming-specific knobs; StreamingPerformanceCase uses framework defaults when launched from CLI.