### PR TITLE
Fix Skip File Validation When Offline with Existing Datasets

### DIFF
--- a/vectordb_bench/backend/data_source.py
+++ b/vectordb_bench/backend/data_source.py
@@ -86,9 +86,13 @@ class AliyunOSSReader(DatasetReader):
                 remote_file = pathlib.PurePosixPath("benchmark", dataset, file)
                 local_file = local_ds_root.joinpath(file)
 
-                if (not local_file.exists()) or (not self.validate_file(remote_file, local_file)):
-                    log.info(f"local file: {local_file} not match with remote: {remote_file}; add to downloading list")
+                # if (not local_file.exists()) or (not self.validate_file(remote_file, local_file)):
+                #    log.info(f"local file: {local_file} not match with remote: {remote_file}; add to downloading list")
+                if not local_file.exists():
+                    log.info(f"local file: {local_file} not exist; add to downloading list")
                     downloads.append((remote_file, local_file))
+                else:
+                    log.info(f"local file: {local_file} already exists, skip download")
 
         if len(downloads) == 0:
             return
@@ -130,9 +134,13 @@ class AwsS3Reader(DatasetReader):
                 remote_file = pathlib.PurePosixPath(self.remote_root, dataset, file)
                 local_file = local_ds_root.joinpath(file)
 
-                if (not local_file.exists()) or (not self.validate_file(remote_file, local_file)):
-                    log.info(f"local file: {local_file} not match with remote: {remote_file}; add to downloading list")
+                # if (not local_file.exists()) or (not self.validate_file(remote_file, local_file)):
+                #    log.info(f"local file: {local_file} not match with remote: {remote_file}; add to downloading list")
+                if not local_file.exists():
+                    log.info(f"local file: {local_file} not exist; add to downloading list")
                     downloads.append(remote_file)
+                else:
+                    log.info(f"local file: {local_file} already exists, skip download")  
 
         if len(downloads) == 0:
             return


### PR DESCRIPTION
## Description
When internet access is unavailable and a dataset has already been downloaded locally, the log output display it's still attempts file validation against remote servers, causing unnecessary failures.

## Finished display


Successfully bypassed Alibaba Cloud (OSS) and Amazon S3 file size validation checks when corresponding datasets are already available locally.