### PR TITLE
(feat) Add Turbopuffer namespace pinning CLI

### DIFF
--- a/tests/test_turbopuffer_cli.py
+++ b/tests/test_turbopuffer_cli.py
@@ -12,8 +12,8 @@ def test_pin_namespace_is_applied_once_before_benchmark(monkeypatch):
         calls.append((method, payload, api_key, region, namespace, api_base_url))
         return {}
 
-    def fake_wait_for_pinning(api_key, region, namespace, replicas, api_base_url=None):
-        calls.append(("WAIT", replicas, api_key, region, namespace, api_base_url))
+    def fake_wait_for_pinning(api_key, region, namespace, replicas, api_base_url=None, timeout=None):
+        calls.append(("WAIT", replicas, api_key, region, namespace, api_base_url, timeout))
         return {"pinning": {"replicas": replicas, "status": {"ready_replicas": replicas}}}
 
     def fake_run(**kwargs):
@@ -35,6 +35,8 @@ def test_pin_namespace_is_applied_once_before_benchmark(monkeypatch):
             "--pin-namespace",
             "--pin-replicas",
             "1",
+            "--pin-timeout",
+            "7200",
             "--case-type",
             "Performance768D100M",
             "--skip-drop-old",
@@ -45,7 +47,42 @@ def test_pin_namespace_is_applied_once_before_benchmark(monkeypatch):
     assert result.exit_code == 0, result.output
     assert calls == [
         ("PATCH", {"pinning": {"replicas": 1}}, "test-key", "aws-us-west-2", "test-ns", None),
-        ("WAIT", 1, "test-key", "aws-us-west-2", "test-ns", None),
+        ("WAIT", 1, "test-key", "aws-us-west-2", "test-ns", None, 7200),
     ]
     assert captured["db_config"].pin_namespace is False
     assert captured["db_config"].pin_replicas == 1
+
+
+def test_unpin_namespace_uses_pin_timeout(monkeypatch):
+    calls = []
+
+    def fake_metadata_request(api_key, region, namespace, method, payload=None, api_base_url=None):
+        calls.append((method, payload, api_key, region, namespace, api_base_url))
+        return {}
+
+    def fake_wait_for_pinning(api_key, region, namespace, replicas, api_base_url=None, timeout=None):
+        calls.append(("WAIT", replicas, api_key, region, namespace, api_base_url, timeout))
+        return {"pinning": None}
+
+    monkeypatch.setattr(tpuf_client, "namespace_metadata_request", fake_metadata_request)
+    monkeypatch.setattr(tpuf_client, "wait_for_namespace_pinning", fake_wait_for_pinning)
+
+    result = CliRunner().invoke(
+        tpuf_cli.TurboPufferUnpin,
+        [
+            "--api-key",
+            "test-key",
+            "--region",
+            "aws-us-west-2",
+            "--namespace",
+            "test-ns",
+            "--pin-timeout",
+            "7200",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("PATCH", {"pinning": None}, "test-key", "aws-us-west-2", "test-ns", None),
+        ("WAIT", None, "test-key", "aws-us-west-2", "test-ns", None, 7200),
+    ]

--- a/tests/test_turbopuffer_cli.py
+++ b/tests/test_turbopuffer_cli.py
@@ -1,0 +1,51 @@
+from click.testing import CliRunner
+
+from vectordb_bench.backend.clients.turbopuffer import cli as tpuf_cli
+from vectordb_bench.backend.clients.turbopuffer import turbopuffer as tpuf_client
+
+
+def test_pin_namespace_is_applied_once_before_benchmark(monkeypatch):
+    calls = []
+    captured = {}
+
+    def fake_metadata_request(api_key, region, namespace, method, payload=None, api_base_url=None):
+        calls.append((method, payload, api_key, region, namespace, api_base_url))
+        return {}
+
+    def fake_wait_for_pinning(api_key, region, namespace, replicas, api_base_url=None):
+        calls.append(("WAIT", replicas, api_key, region, namespace, api_base_url))
+        return {"pinning": {"replicas": replicas, "status": {"ready_replicas": replicas}}}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(tpuf_client, "namespace_metadata_request", fake_metadata_request)
+    monkeypatch.setattr(tpuf_client, "wait_for_namespace_pinning", fake_wait_for_pinning)
+    monkeypatch.setattr(tpuf_cli, "run", fake_run)
+
+    result = CliRunner().invoke(
+        tpuf_cli.TurboPuffer,
+        [
+            "--api-key",
+            "test-key",
+            "--region",
+            "aws-us-west-2",
+            "--namespace",
+            "test-ns",
+            "--pin-namespace",
+            "--pin-replicas",
+            "1",
+            "--case-type",
+            "Performance768D100M",
+            "--skip-drop-old",
+            "--skip-load",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("PATCH", {"pinning": {"replicas": 1}}, "test-key", "aws-us-west-2", "test-ns", None),
+        ("WAIT", 1, "test-key", "aws-us-west-2", "test-ns", None),
+    ]
+    assert captured["db_config"].pin_namespace is False
+    assert captured["db_config"].pin_replicas == 1

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -103,13 +103,16 @@ def TurboPuffer(**parameters: Unpack[TurboPufferIndexTypedDict]):
 @cli.command()
 @click_parameter_decorators_from_typed_dict(TurboPufferUnpinTypedDict)
 def TurboPufferUnpin(**parameters: Unpack[TurboPufferUnpinTypedDict]):
-    from .turbopuffer import patch_namespace_metadata
+    from .turbopuffer import patch_namespace_metadata, wait_for_namespace_pinning
 
-    meta = patch_namespace_metadata(
+    patch_namespace_metadata(
         parameters["api_key"],
         parameters["region"],
         parameters["namespace"],
         {"pinning": None},
         parameters["api_base_url"] or None,
+    )
+    meta = wait_for_namespace_pinning(
+        parameters["api_key"], parameters["region"], parameters["namespace"], None, parameters["api_base_url"] or None
     )
     click.echo(f"TurboPuffer namespace unpinned: {parameters['namespace']} pinning={meta.get('pinning')}")

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -13,43 +13,58 @@ from .. import DB
 
 DEFAULT_PIN_TIMEOUT = 45 * 60
 
+ApiKeyOption = Annotated[
+    str,
+    click.option("--api-key", type=str, help="TurboPuffer API key", required=True),
+]
+RegionOption = Annotated[
+    str,
+    click.option(
+        "--region",
+        type=str,
+        help="TurboPuffer region (e.g. aws-us-east-1, gcp-us-central1)",
+        required=True,
+    ),
+]
+ApiBaseUrlOption = Annotated[
+    str,
+    click.option(
+        "--api-base-url",
+        type=str,
+        help="Override the region-based API URL",
+        required=False,
+        default="",
+        show_default=False,
+    ),
+]
+NamespaceOption = Annotated[
+    str,
+    click.option(
+        "--namespace",
+        type=str,
+        help="TurboPuffer namespace",
+        required=False,
+        default="vdbbench_test",
+        show_default=True,
+    ),
+]
+PinTimeoutOption = Annotated[
+    int,
+    click.option(
+        "--pin-timeout",
+        type=click.IntRange(min=1),
+        default=DEFAULT_PIN_TIMEOUT,
+        show_default=True,
+        help="Seconds to wait for TurboPuffer namespace pinning or unpinning to complete",
+    ),
+]
+
 
 class TurboPufferTypedDict(TypedDict):
-    api_key: Annotated[
-        str,
-        click.option("--api-key", type=str, help="TurboPuffer API key", required=True),
-    ]
-    region: Annotated[
-        str,
-        click.option(
-            "--region",
-            type=str,
-            help="TurboPuffer region (e.g. aws-us-east-1, gcp-us-central1)",
-            required=True,
-        ),
-    ]
-    api_base_url: Annotated[
-        str,
-        click.option(
-            "--api-base-url",
-            type=str,
-            help="Override the region-based API URL",
-            required=False,
-            default="",
-            show_default=False,
-        ),
-    ]
-    namespace: Annotated[
-        str,
-        click.option(
-            "--namespace",
-            type=str,
-            help="TurboPuffer namespace",
-            required=False,
-            default="vdbbench_test",
-            show_default=True,
-        ),
-    ]
+    api_key: ApiKeyOption
+    region: RegionOption
+    api_base_url: ApiBaseUrlOption
+    namespace: NamespaceOption
     pin_namespace: Annotated[
         bool,
         click.option(
@@ -69,27 +84,18 @@ class TurboPufferTypedDict(TypedDict):
             help="Number of TurboPuffer pinning replicas to request",
         ),
     ]
-    pin_timeout: Annotated[
-        int,
-        click.option(
-            "--pin-timeout",
-            type=click.IntRange(min=1),
-            default=DEFAULT_PIN_TIMEOUT,
-            show_default=True,
-            help="Seconds to wait for TurboPuffer namespace pinning or unpinning to complete",
-        ),
-    ]
+    pin_timeout: PinTimeoutOption
 
 
 class TurboPufferIndexTypedDict(CommonTypedDict, TurboPufferTypedDict): ...
 
 
 class TurboPufferUnpinTypedDict(TypedDict):
-    api_key: TurboPufferTypedDict.__annotations__["api_key"]
-    region: TurboPufferTypedDict.__annotations__["region"]
-    api_base_url: TurboPufferTypedDict.__annotations__["api_base_url"]
-    namespace: TurboPufferTypedDict.__annotations__["namespace"]
-    pin_timeout: TurboPufferTypedDict.__annotations__["pin_timeout"]
+    api_key: ApiKeyOption
+    region: RegionOption
+    api_base_url: ApiBaseUrlOption
+    namespace: NamespaceOption
+    pin_timeout: PinTimeoutOption
 
 
 def pin_namespace_once(parameters: TurboPufferIndexTypedDict):

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -103,12 +103,13 @@ def TurboPuffer(**parameters: Unpack[TurboPufferIndexTypedDict]):
 @cli.command()
 @click_parameter_decorators_from_typed_dict(TurboPufferUnpinTypedDict)
 def TurboPufferUnpin(**parameters: Unpack[TurboPufferUnpinTypedDict]):
-    from .turbopuffer import patch_namespace_metadata, wait_for_namespace_pinning
+    from .turbopuffer import namespace_metadata_request, wait_for_namespace_pinning
 
-    patch_namespace_metadata(
+    namespace_metadata_request(
         parameters["api_key"],
         parameters["region"],
         parameters["namespace"],
+        "PATCH",
         {"pinning": None},
         parameters["api_base_url"] or None,
     )

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -11,6 +11,8 @@ from ....cli.cli import (
 )
 from .. import DB
 
+DEFAULT_PIN_TIMEOUT = 45 * 60
+
 
 class TurboPufferTypedDict(TypedDict):
     api_key: Annotated[
@@ -67,6 +69,16 @@ class TurboPufferTypedDict(TypedDict):
             help="Number of TurboPuffer pinning replicas to request",
         ),
     ]
+    pin_timeout: Annotated[
+        int,
+        click.option(
+            "--pin-timeout",
+            type=click.IntRange(min=1),
+            default=DEFAULT_PIN_TIMEOUT,
+            show_default=True,
+            help="Seconds to wait for TurboPuffer namespace pinning or unpinning to complete",
+        ),
+    ]
 
 
 class TurboPufferIndexTypedDict(CommonTypedDict, TurboPufferTypedDict): ...
@@ -77,6 +89,7 @@ class TurboPufferUnpinTypedDict(TypedDict):
     region: TurboPufferTypedDict.__annotations__["region"]
     api_base_url: TurboPufferTypedDict.__annotations__["api_base_url"]
     namespace: TurboPufferTypedDict.__annotations__["namespace"]
+    pin_timeout: TurboPufferTypedDict.__annotations__["pin_timeout"]
 
 
 def pin_namespace_once(parameters: TurboPufferIndexTypedDict):
@@ -96,6 +109,7 @@ def pin_namespace_once(parameters: TurboPufferIndexTypedDict):
         parameters["namespace"],
         parameters["pin_replicas"],
         parameters["api_base_url"] or None,
+        parameters["pin_timeout"],
     )
 
 
@@ -137,6 +151,11 @@ def TurboPufferUnpin(**parameters: Unpack[TurboPufferUnpinTypedDict]):
         parameters["api_base_url"] or None,
     )
     meta = wait_for_namespace_pinning(
-        parameters["api_key"], parameters["region"], parameters["namespace"], None, parameters["api_base_url"] or None
+        parameters["api_key"],
+        parameters["region"],
+        parameters["namespace"],
+        None,
+        parameters["api_base_url"] or None,
+        parameters["pin_timeout"],
     )
     click.echo(f"TurboPuffer namespace unpinned: {parameters['namespace']} pinning={meta.get('pinning')}")

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -91,6 +91,15 @@ class TurboPufferIndexTypedDict(CommonTypedDict, TurboPufferTypedDict): ...
 
 
 class TurboPufferUnpinTypedDict(TypedDict):
+    """Options for explicit TurboPuffer namespace pinning cleanup.
+
+    Namespace pinning is persistent service state: enabling it before a benchmark
+    reserves replicas for the namespace until it is cleared.  Unpinning is kept
+    as a separate command so failed or interrupted benchmark runs can be cleaned
+    up later, and so a billing-affecting teardown action is not hidden behind
+    ordinary benchmark flags.
+    """
+
     api_key: ApiKeyOption
     region: RegionOption
     api_base_url: ApiBaseUrlOption

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -48,9 +48,35 @@ class TurboPufferTypedDict(TypedDict):
             show_default=True,
         ),
     ]
+    pin_namespace: Annotated[
+        bool,
+        click.option(
+            "--pin-namespace/--no-pin-namespace",
+            default=False,
+            show_default=True,
+            help="Enable TurboPuffer namespace pinning before the benchmark runs",
+        ),
+    ]
+    pin_replicas: Annotated[
+        int,
+        click.option(
+            "--pin-replicas",
+            type=click.IntRange(min=1),
+            default=1,
+            show_default=True,
+            help="Number of TurboPuffer pinning replicas to request",
+        ),
+    ]
 
 
 class TurboPufferIndexTypedDict(CommonTypedDict, TurboPufferTypedDict): ...
+
+
+class TurboPufferUnpinTypedDict(TypedDict):
+    api_key: TurboPufferTypedDict.__annotations__["api_key"]
+    region: TurboPufferTypedDict.__annotations__["region"]
+    api_base_url: TurboPufferTypedDict.__annotations__["api_base_url"]
+    namespace: TurboPufferTypedDict.__annotations__["namespace"]
 
 
 @cli.command()
@@ -66,7 +92,24 @@ def TurboPuffer(**parameters: Unpack[TurboPufferIndexTypedDict]):
             region=parameters["region"],
             api_base_url=parameters["api_base_url"] or None,
             namespace=parameters["namespace"],
+            pin_namespace=parameters["pin_namespace"],
+            pin_replicas=parameters["pin_replicas"],
         ),
         db_case_config=TurboPufferIndexConfig(),
         **parameters,
     )
+
+
+@cli.command()
+@click_parameter_decorators_from_typed_dict(TurboPufferUnpinTypedDict)
+def TurboPufferUnpin(**parameters: Unpack[TurboPufferUnpinTypedDict]):
+    from .turbopuffer import patch_namespace_metadata
+
+    meta = patch_namespace_metadata(
+        parameters["api_key"],
+        parameters["region"],
+        parameters["namespace"],
+        {"pinning": None},
+        parameters["api_base_url"] or None,
+    )
+    click.echo(f"TurboPuffer namespace unpinned: {parameters['namespace']} pinning={meta.get('pinning')}")

--- a/vectordb_bench/backend/clients/turbopuffer/cli.py
+++ b/vectordb_bench/backend/clients/turbopuffer/cli.py
@@ -79,10 +79,33 @@ class TurboPufferUnpinTypedDict(TypedDict):
     namespace: TurboPufferTypedDict.__annotations__["namespace"]
 
 
+def pin_namespace_once(parameters: TurboPufferIndexTypedDict):
+    from .turbopuffer import namespace_metadata_request, wait_for_namespace_pinning
+
+    namespace_metadata_request(
+        parameters["api_key"],
+        parameters["region"],
+        parameters["namespace"],
+        "PATCH",
+        {"pinning": {"replicas": parameters["pin_replicas"]}},
+        parameters["api_base_url"] or None,
+    )
+    wait_for_namespace_pinning(
+        parameters["api_key"],
+        parameters["region"],
+        parameters["namespace"],
+        parameters["pin_replicas"],
+        parameters["api_base_url"] or None,
+    )
+
+
 @cli.command()
 @click_parameter_decorators_from_typed_dict(TurboPufferIndexTypedDict)
 def TurboPuffer(**parameters: Unpack[TurboPufferIndexTypedDict]):
     from .config import TurboPufferConfig, TurboPufferIndexConfig
+
+    if parameters["pin_namespace"]:
+        pin_namespace_once(parameters)
 
     run(
         db=DB.TurboPuffer,
@@ -92,7 +115,7 @@ def TurboPuffer(**parameters: Unpack[TurboPufferIndexTypedDict]):
             region=parameters["region"],
             api_base_url=parameters["api_base_url"] or None,
             namespace=parameters["namespace"],
-            pin_namespace=parameters["pin_namespace"],
+            pin_namespace=False,
             pin_replicas=parameters["pin_replicas"],
         ),
         db_case_config=TurboPufferIndexConfig(),

--- a/vectordb_bench/backend/clients/turbopuffer/config.py
+++ b/vectordb_bench/backend/clients/turbopuffer/config.py
@@ -8,6 +8,8 @@ class TurboPufferConfig(DBConfig):
     region: str
     api_base_url: str | None = None
     namespace: str = "vdbbench_test"
+    pin_namespace: bool = False
+    pin_replicas: int = 1
 
     def to_dict(self) -> dict:
         return {
@@ -15,6 +17,8 @@ class TurboPufferConfig(DBConfig):
             "region": self.region,
             "api_base_url": self.api_base_url,
             "namespace": self.namespace,
+            "pin_namespace": self.pin_namespace,
+            "pin_replicas": self.pin_replicas,
         }
 
 

--- a/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
+++ b/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
@@ -16,17 +16,19 @@ from vectordb_bench.backend.filter import Filter, FilterOp
 from ..api import VectorDB
 
 log = logging.getLogger(__name__)
+PINNING_POLL_INTERVAL = 10
+PINNING_TIMEOUT = 45 * 60
 
 
-def patch_namespace_metadata(
-    api_key: str, region: str, namespace: str, payload: dict, api_base_url: str | None = None
+def namespace_metadata_request(
+    api_key: str, region: str, namespace: str, method: str, payload=None, api_base_url=None
 ) -> dict:
     base_url = api_base_url or f"https://{region}.turbopuffer.com"
     url = f"{base_url.rstrip('/')}/v1/namespaces/{quote(namespace, safe='')}/metadata"
     req = Request(
         url,
-        data=dumps(payload).encode(),
-        method="PATCH",
+        data=dumps(payload).encode() if payload is not None else None,
+        method=method,
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -38,6 +40,30 @@ def patch_namespace_metadata(
     except HTTPError as e:
         detail = e.read().decode(errors="replace")
         raise RuntimeError(f"Failed to update TurboPuffer namespace metadata: {e.code} {detail}") from e
+
+
+def patch_namespace_metadata(api_key: str, region: str, namespace: str, payload: dict, api_base_url=None) -> dict:
+    return namespace_metadata_request(api_key, region, namespace, "PATCH", payload, api_base_url)
+
+
+def wait_for_namespace_pinning(
+    api_key: str, region: str, namespace: str, replicas: int | None, api_base_url=None
+) -> dict:
+    deadline = time.monotonic() + PINNING_TIMEOUT
+    while True:
+        meta = namespace_metadata_request(api_key, region, namespace, "GET", api_base_url=api_base_url)
+        pinning = meta.get("pinning")
+        if replicas is None:
+            if pinning is None:
+                return meta
+        else:
+            status = pinning.get("status", {}) if isinstance(pinning, dict) else {}
+            if pinning and pinning.get("replicas") == replicas and status.get("ready_replicas") == replicas:
+                return meta
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"Timed out waiting for TurboPuffer pinning state on namespace {namespace}")
+        log.info("Waiting for TurboPuffer pinning state: %s", pinning)
+        time.sleep(PINNING_POLL_INTERVAL)
 
 
 class TurboPuffer(VectorDB):
@@ -97,6 +123,9 @@ class TurboPuffer(VectorDB):
             self.namespace,
             {"pinning": {"replicas": self.pin_replicas}},
             self.api_base_url,
+        )
+        meta = wait_for_namespace_pinning(
+            self.api_key, self.region, self.namespace, self.pin_replicas, self.api_base_url
         )
         pinning = meta.get("pinning", {})
         status = pinning.get("status", {})

--- a/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
+++ b/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
@@ -4,6 +4,7 @@ import logging
 import time
 from contextlib import contextmanager
 from json import dumps, loads
+from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -21,11 +22,16 @@ PINNING_TIMEOUT = 45 * 60
 
 
 def namespace_metadata_request(
-    api_key: str, region: str, namespace: str, method: str, payload=None, api_base_url=None
+    api_key: str,
+    region: str,
+    namespace: str,
+    method: str,
+    payload: dict[str, Any] | None = None,
+    api_base_url: str | None = None,
 ) -> dict:
     base_url = api_base_url or f"https://{region}.turbopuffer.com"
     url = f"{base_url.rstrip('/')}/v1/namespaces/{quote(namespace, safe='')}/metadata"
-    req = Request(
+    req = Request(  # noqa: S310
         url,
         data=dumps(payload).encode() if payload is not None else None,
         method=method,
@@ -35,11 +41,12 @@ def namespace_metadata_request(
         },
     )
     try:
-        with urlopen(req, timeout=60) as resp:
+        with urlopen(req, timeout=60) as resp:  # noqa: S310
             return loads(resp.read().decode() or "{}")
     except HTTPError as e:
         detail = e.read().decode(errors="replace")
-        raise RuntimeError(f"Failed to update TurboPuffer namespace metadata: {e.code} {detail}") from e
+        msg = f"Failed to update TurboPuffer namespace metadata: {e.code} {detail}"
+        raise RuntimeError(msg) from e
 
 
 def wait_for_namespace_pinning(
@@ -47,7 +54,7 @@ def wait_for_namespace_pinning(
     region: str,
     namespace: str,
     replicas: int | None,
-    api_base_url=None,
+    api_base_url: str | None = None,
     timeout: int = PINNING_TIMEOUT,
 ) -> dict:
     deadline = time.monotonic() + timeout
@@ -62,7 +69,8 @@ def wait_for_namespace_pinning(
             if pinning and pinning.get("replicas") == replicas and status.get("ready_replicas") == replicas:
                 return meta
         if time.monotonic() >= deadline:
-            raise TimeoutError(f"Timed out waiting for TurboPuffer pinning state on namespace {namespace}")
+            msg = f"Timed out waiting for TurboPuffer pinning state on namespace {namespace}"
+            raise TimeoutError(msg)
         log.info("Waiting for TurboPuffer pinning state: %s", pinning)
         time.sleep(PINNING_POLL_INTERVAL)
 

--- a/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
+++ b/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
@@ -3,6 +3,10 @@
 import logging
 import time
 from contextlib import contextmanager
+from json import dumps, loads
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
 
 import turbopuffer as tpuf
 
@@ -12,6 +16,28 @@ from vectordb_bench.backend.filter import Filter, FilterOp
 from ..api import VectorDB
 
 log = logging.getLogger(__name__)
+
+
+def patch_namespace_metadata(
+    api_key: str, region: str, namespace: str, payload: dict, api_base_url: str | None = None
+) -> dict:
+    base_url = api_base_url or f"https://{region}.turbopuffer.com"
+    url = f"{base_url.rstrip('/')}/v1/namespaces/{quote(namespace, safe='')}/metadata"
+    req = Request(
+        url,
+        data=dumps(payload).encode(),
+        method="PATCH",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urlopen(req, timeout=60) as resp:
+            return loads(resp.read().decode() or "{}")
+    except HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        raise RuntimeError(f"Failed to update TurboPuffer namespace metadata: {e.code} {detail}") from e
 
 
 class TurboPuffer(VectorDB):
@@ -34,6 +60,9 @@ class TurboPuffer(VectorDB):
         self.region = db_config.get("region", "")
         self.api_base_url = db_config.get("api_base_url")
         self.namespace = db_config.get("namespace", "")
+        self.pin_namespace = db_config.get("pin_namespace", False)
+        self.pin_replicas = db_config.get("pin_replicas", 1)
+        self._pinning_applied = False
         self.db_case_config = db_case_config
         self.metric = db_case_config.parse_metric()
 
@@ -59,10 +88,30 @@ class TurboPuffer(VectorDB):
             client_kwargs["base_url"] = self.api_base_url
         return tpuf.Turbopuffer(**client_kwargs)
 
+    def _apply_namespace_pinning(self):
+        if not self.pin_namespace or self._pinning_applied:
+            return
+        meta = patch_namespace_metadata(
+            self.api_key,
+            self.region,
+            self.namespace,
+            {"pinning": {"replicas": self.pin_replicas}},
+            self.api_base_url,
+        )
+        pinning = meta.get("pinning", {})
+        status = pinning.get("status", {})
+        log.info(
+            "TurboPuffer pinning requested: replicas=%s ready_replicas=%s",
+            pinning.get("replicas", self.pin_replicas),
+            status.get("ready_replicas"),
+        )
+        self._pinning_applied = True
+
     @contextmanager
     def init(self):
         self.client = self._create_client()
         self.ns = self.client.namespace(self.namespace)
+        self._apply_namespace_pinning()
         yield
 
     def optimize(self, data_size: int | None = None):

--- a/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
+++ b/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
@@ -42,10 +42,6 @@ def namespace_metadata_request(
         raise RuntimeError(f"Failed to update TurboPuffer namespace metadata: {e.code} {detail}") from e
 
 
-def patch_namespace_metadata(api_key: str, region: str, namespace: str, payload: dict, api_base_url=None) -> dict:
-    return namespace_metadata_request(api_key, region, namespace, "PATCH", payload, api_base_url)
-
-
 def wait_for_namespace_pinning(
     api_key: str, region: str, namespace: str, replicas: int | None, api_base_url=None
 ) -> dict:
@@ -117,10 +113,11 @@ class TurboPuffer(VectorDB):
     def _apply_namespace_pinning(self):
         if not self.pin_namespace or self._pinning_applied:
             return
-        meta = patch_namespace_metadata(
+        meta = namespace_metadata_request(
             self.api_key,
             self.region,
             self.namespace,
+            "PATCH",
             {"pinning": {"replicas": self.pin_replicas}},
             self.api_base_url,
         )

--- a/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
+++ b/vectordb_bench/backend/clients/turbopuffer/turbopuffer.py
@@ -43,9 +43,14 @@ def namespace_metadata_request(
 
 
 def wait_for_namespace_pinning(
-    api_key: str, region: str, namespace: str, replicas: int | None, api_base_url=None
+    api_key: str,
+    region: str,
+    namespace: str,
+    replicas: int | None,
+    api_base_url=None,
+    timeout: int = PINNING_TIMEOUT,
 ) -> dict:
-    deadline = time.monotonic() + PINNING_TIMEOUT
+    deadline = time.monotonic() + timeout
     while True:
         meta = namespace_metadata_request(api_key, region, namespace, "GET", api_base_url=api_base_url)
         pinning = meta.get("pinning")

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -39,7 +39,7 @@ from ..backend.clients.seekdb.cli import SeekDBHNSW
 from ..backend.clients.tencent_elasticsearch.cli import TencentElasticsearch
 from ..backend.clients.test.cli import Test
 from ..backend.clients.tidb.cli import TiDB
-from ..backend.clients.turbopuffer.cli import TurboPuffer
+from ..backend.clients.turbopuffer.cli import TurboPuffer, TurboPufferUnpin
 from ..backend.clients.vectorchord.cli import VectorChordGraph, VectorChordRQ
 from ..backend.clients.vespa.cli import Vespa
 from ..backend.clients.weaviate_cloud.cli import Weaviate
@@ -83,6 +83,7 @@ cli.add_command(TencentElasticsearch)
 cli.add_command(AliSQLHNSW)
 cli.add_command(Doris)
 cli.add_command(TurboPuffer)
+cli.add_command(TurboPufferUnpin)
 cli.add_command(Chroma)
 cli.add_command(Zvec)
 cli.add_command(Endee)


### PR DESCRIPTION
## Summary
- Add `--pin-namespace/--no-pin-namespace` and `--pin-replicas` to the Turbopuffer benchmark CLI.
- PATCH Turbopuffer namespace metadata to request pinning before benchmark operations when explicitly enabled.
- Add `TurboPufferUnpin` CLI command to clear namespace pinning after benchmark runs.

## Test Plan
- `python -m py_compile vectordb_bench/backend/clients/turbopuffer/cli.py vectordb_bench/backend/clients/turbopuffer/config.py vectordb_bench/backend/clients/turbopuffer/turbopuffer.py vectordb_bench/cli/vectordbbench.py`
- Stubbed metadata PATCH smoke test for unpin payload (`{"pinning": null}`), no real Turbopuffer API calls made.

## Notes
- Full test suite was not run in the local checkout because the environment is missing the broader VectorDBBench dependency stack.
