### PR TITLE
feat(oceanbase): configurable index params, KEY partitioning, HNSW_BQ cosine support  

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ turbopuffer     = [ "turbopuffer" ]
 zvec            = [ "zvec" ]
 endee           = [ "endee==0.1.10" ]
 lindorm         = [ "opensearch-py" ]
+seekdb          = [ "mysql-connector-python" ]
 pinot           = [ "requests" ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["vectordb_bench", "vectordb_bench.cli"]
+include = ["vectordb_bench", "vectordb_bench.*"]
 
 [project]
 name = "vectordb-bench"
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "click",
+    "pyyaml",
     "pytz",
     "streamlit>=1.47,<2",  # 1.47 fixes streamlit#11660
     "tqdm",
@@ -80,7 +81,6 @@ turbopuffer     = [ "turbopuffer" ]
 zvec            = [ "zvec" ]
 endee           = [ "endee==0.1.10" ]
 lindorm         = [ "opensearch-py" ]
-seekdb          = [ "mysql-connector-python" ]
 pinot           = [ "requests" ]
 
 [project.urls]

--- a/vectordb_bench/backend/clients/oceanbase/cli.py
+++ b/vectordb_bench/backend/clients/oceanbase/cli.py
@@ -31,9 +31,40 @@ class OceanBaseTypedDict(CommonTypedDict):
     ]
     database: Annotated[str, click.option("--database", type=str, help="DataBase name", required=True)]
     port: Annotated[int, click.option("--port", type=int, help="OceanBase port", required=True)]
+    create_index_parallel: Annotated[
+        int,
+        click.option(
+            "--create-index-parallel",
+            type=int,
+            default=16,
+            show_default=True,
+            help="PARALLEL hint degree for CREATE VECTOR INDEX",
+        ),
+    ]
+    partitions: Annotated[
+        int,
+        click.option(
+            "--partitions",
+            type=int,
+            default=0,
+            show_default=True,
+            help="Number of KEY partitions for the table. 0 or 1 means no partitioning.",
+        ),
+    ]
 
 
-class OceanBaseHNSWTypedDict(CommonTypedDict, OceanBaseTypedDict, HNSWFlavor4): ...
+class OceanBaseHNSWTypedDict(CommonTypedDict, OceanBaseTypedDict, HNSWFlavor4):
+    extra_info_max_size: Annotated[
+        int | None,
+        click.option(
+            "--extra-info-max-size",
+            type=int,
+            default=32,
+            show_default=True,
+            help="extra_info_max_size for HNSW index. Set to 0 to omit.",
+            required=False,
+        ),
+    ]
 
 
 @cli.command()
@@ -55,6 +86,9 @@ def OceanBaseHNSW(**parameters: Unpack[OceanBaseHNSWTypedDict]):
             m=parameters["m"],
             efConstruction=parameters["ef_construction"],
             ef_search=parameters["ef_search"],
+            extra_info_max_size=parameters["extra_info_max_size"] or None,
+            create_index_parallel=parameters["create_index_parallel"],
+            partitions=parameters["partitions"],
             index=parameters["index_type"],
         ),
         **parameters,
@@ -94,6 +128,8 @@ def OceanBaseIVF(**parameters: Unpack[OceanBaseIVFTypedDict]):
             nlist=parameters["nlist"],
             sample_per_nlist=parameters["sample_per_nlist"],
             nbits=parameters["nbits"],
+            create_index_parallel=parameters["create_index_parallel"],
+            partitions=parameters["partitions"],
             index=input_index_type,
             ivf_nprobes=parameters["ivf_nprobes"],
         ),

--- a/vectordb_bench/backend/clients/oceanbase/config.py
+++ b/vectordb_bench/backend/clients/oceanbase/config.py
@@ -36,20 +36,18 @@ class OceanBaseIndexConfig(BaseModel):
     index: IndexType
     metric_type: MetricType | None = None
     lib: str = "vsag"
+    create_index_parallel: int = 16
+    partitions: int = 0
 
     def parse_metric(self) -> str:
-        if self.metric_type == MetricType.L2 or (
-            self.index == IndexType.HNSW_BQ and self.metric_type == MetricType.COSINE
-        ):
+        if self.metric_type == MetricType.L2:
             return "l2"
         if self.metric_type == MetricType.IP:
             return "inner_product"
         return "cosine"
 
     def parse_metric_func_str(self) -> str:
-        if self.metric_type == MetricType.L2 or (
-            self.index == IndexType.HNSW_BQ and self.metric_type == MetricType.COSINE
-        ):
+        if self.metric_type == MetricType.L2:
             return "l2_distance"
         if self.metric_type == MetricType.IP:
             return "negative_inner_product"
@@ -60,6 +58,7 @@ class OceanBaseHNSWConfig(OceanBaseIndexConfig, DBCaseConfig):
     m: int
     efConstruction: int
     ef_search: int | None = None
+    extra_info_max_size: int | None = 32
     index: IndexType
 
     def index_param(self) -> dict:

--- a/vectordb_bench/backend/clients/oceanbase/oceanbase.py
+++ b/vectordb_bench/backend/clients/oceanbase/oceanbase.py
@@ -23,6 +23,8 @@ class OceanBase(VectorDB):
         FilterOp.NumGE,
         FilterOp.StrEqual,
     ]
+    # mysql-connector cursor cannot be shared across threads
+    thread_safe: bool = False
 
     def __init__(
         self,

--- a/vectordb_bench/backend/clients/oceanbase/oceanbase.py
+++ b/vectordb_bench/backend/clients/oceanbase/oceanbase.py
@@ -109,27 +109,28 @@ class OceanBase(VectorDB):
         if not self._cursor:
             raise ValueError("Cursor is not initialized")
 
-        log.info(f"Creating table {self.table_name}")
-        create_table_query = f"""
-        CREATE TABLE {self.table_name} (
-            id INT PRIMARY KEY,
-            embedding VECTOR({self.dim})
-        );
-        """
+        partitions = getattr(self.db_case_config, "partitions", 0)
+        log.info(f"Creating table {self.table_name} (partitions={partitions})")
+
+        create_table_query = f"CREATE TABLE {self.table_name} (id INT PRIMARY KEY, embedding VECTOR({self.dim}))"
+        if partitions > 1:
+            create_table_query += f" PARTITION BY KEY(id) PARTITIONS {partitions}"
+        create_table_query += ";"
         self._cursor.execute(create_table_query)
 
     def optimize(self, data_size: int):
         index_params = self.db_case_config.index_param()
         index_args = ", ".join(f"{k}={v}" for k, v in index_params["params"].items())
         index_query = (
-            f"CREATE /*+ PARALLEL(18) */ VECTOR INDEX idx1 "
+            f"CREATE /*+ PARALLEL({self.db_case_config.create_index_parallel}) */ VECTOR INDEX idx1 "
             f"ON {self.table_name}(embedding) "
             f"WITH (distance={self.db_case_config.parse_metric()}, "
             f"type={index_params['index_type']}, lib={index_params['lib']}, {index_args}"
         )
 
-        if self.db_case_config.index in {IndexType.HNSW, IndexType.HNSW_SQ, IndexType.HNSW_BQ}:
-            index_query += ", extra_info_max_size=32"
+        extra_info = getattr(self.db_case_config, "extra_info_max_size", None)
+        if extra_info is not None:
+            index_query += f", extra_info_max_size={extra_info}"
 
         index_query += ")"
 
@@ -153,10 +154,6 @@ class OceanBase(VectorDB):
             raise
 
     def need_normalize_cosine(self) -> bool:
-        if self.db_case_config.index == IndexType.HNSW_BQ:
-            log.info("current HNSW_BQ only supports L2, cosine dataset need normalize.")
-            return True
-
         return False
 
     def _wait_for_major_compaction(self):
@@ -185,9 +182,7 @@ class OceanBase(VectorDB):
                 batch_end = min(batch_start + self.load_batch_size, len(embeddings))
                 batch = [(metadata[i], embeddings[i]) for i in range(batch_start, batch_end)]
                 values = ", ".join(f"({item_id}, '[{','.join(map(str, embedding))}]')" for item_id, embedding in batch)
-                self._cursor.execute(
-                    f"INSERT /*+ ENABLE_PARALLEL_DML PARALLEL(32) */ INTO {self.table_name} VALUES {values}"
-                )
+                self._cursor.execute(f"INSERT INTO {self.table_name} VALUES {values}")
                 insert_count += len(batch)
         except mysql.Error:
             log.exception("Failed to insert embeddings")


### PR DESCRIPTION
## Summary
- Add `--create-index-parallel` CLI option (default 16) for configurable index build parallelism
- Add `--extra-info-max-size` CLI option (default 32, set 0 to omit) for HNSW index
- Add `--partitions` CLI option for KEY partitioning (default 0, no partition)
- Declare `thread_safe=False` for OceanBase (mysql-connector cursor cannot be shared across threads)
- HNSW_BQ: remove forced L2 for cosine metric, now supports cosine natively
- `need_normalize_cosine` returns False for all index types
- Remove hardcoded `PARALLEL(32)` hint from INSERT statement
- `pyproject.toml`: add missing `pyyaml` dependency, fix `packages.find` to include all subpackages