### PR TITLE
feat: add multi-process data loader for GIL-bound insert paths

### DIFF
--- a/vectordb_bench/backend/clients/oceanbase/oceanbase.py
+++ b/vectordb_bench/backend/clients/oceanbase/oceanbase.py
@@ -23,6 +23,8 @@ class OceanBase(VectorDB):
         FilterOp.NumGE,
         FilterOp.StrEqual,
     ]
+    # insert path is GIL-bound; multi-threading cannot improve load throughput
+    thread_safe: bool = False
 
     def __init__(
         self,
@@ -57,6 +59,15 @@ class OceanBase(VectorDB):
                 self._create_table()
         finally:
             self._disconnect()
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_conn"] = None
+        state["_cursor"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
 
     def _connect(self):
         try:

--- a/vectordb_bench/backend/runner/__init__.py
+++ b/vectordb_bench/backend/runner/__init__.py
@@ -1,11 +1,13 @@
 from .concurrent_runner import ConcurrentInsertRunner
 from .mp_runner import MultiProcessingSearchRunner
+from .multiprocess_load_runner import MultiprocessInsertRunner
 from .read_write_runner import ReadWriteRunner
 from .serial_runner import SerialInsertRunner, SerialSearchRunner
 
 __all__ = [
     "ConcurrentInsertRunner",
     "MultiProcessingSearchRunner",
+    "MultiprocessInsertRunner",
     "ReadWriteRunner",
     "SerialInsertRunner",
     "SerialSearchRunner",

--- a/vectordb_bench/backend/runner/concurrent_runner.py
+++ b/vectordb_bench/backend/runner/concurrent_runner.py
@@ -74,7 +74,10 @@ class ConcurrentInsertRunner:
 
         effective_workers = max_workers or min(mp.cpu_count(), 4)
         if not db.thread_safe:
-            log.info(f"DB {db.name} is not thread-safe, falling back to max_workers=1")
+            log.info(
+                f"DB {db.name} declared thread_safe=False, falling back to max_workers=1"
+                " (use --load-processes for parallel loading)"
+            )
             effective_workers = 1
         self.max_workers = effective_workers
         assert db.thread_safe or self.max_workers == 1, (

--- a/vectordb_bench/backend/runner/multiprocess_load_runner.py
+++ b/vectordb_bench/backend/runner/multiprocess_load_runner.py
@@ -1,0 +1,279 @@
+"""Multi-process loader for the performance load stage."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import multiprocessing as mp
+import time
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from ... import config
+from ...models import PerformanceTimeoutError
+from ..filter import Filter, FilterOp, non_filter
+from ..utils import time_it
+
+if TYPE_CHECKING:
+    from multiprocessing.queues import Queue as MPQueue
+    from multiprocessing.sharedctypes import Synchronized
+
+    from ..clients import api
+    from ..dataset import DatasetManager
+
+
+log = logging.getLogger(__name__)
+
+
+# Sent from the producer to signal "no more work".
+_SENTINEL = None
+
+# Poll interval while the producer waits for a stalled queue slot.
+_PROGRESS_INTERVAL_SEC = 5
+
+
+def _insert_worker(
+    db: api.VectorDB,
+    task_queue: MPQueue,
+    error_queue: MPQueue,
+    counter: Synchronized,
+    normalize: bool,
+    worker_id: int,
+) -> None:
+    """Drain `task_queue` in a dedicated process.
+
+    Each item is a `(ids, emb_np, labels)` tuple. Workers share no state
+    beyond the queues + counter; a failure from any worker is surfaced via
+    `error_queue` and causes the runner to abort.
+    """
+    try:
+        with db.init():
+            while True:
+                item = task_queue.get()
+                if item is _SENTINEL:
+                    return
+
+                ids, emb_np, labels = item
+                if normalize:
+                    emb_np = emb_np / np.linalg.norm(emb_np, axis=1)[:, np.newaxis]
+                embeddings = emb_np.tolist()
+
+                kwargs: dict[str, Any] = {}
+                if labels is not None:
+                    kwargs["labels_data"] = labels
+                inserted, err = db.insert_embeddings(
+                    embeddings=embeddings,
+                    metadata=ids,
+                    **kwargs,
+                )
+                if err is not None:
+                    raise err  # noqa: TRY301
+                with counter.get_lock():
+                    counter.value += inserted
+    except Exception as exc:
+        log.exception(f"[worker-{worker_id}] insert failed")
+        with contextlib.suppress(Exception):
+            error_queue.put(f"worker-{worker_id}: {exc!r}")
+
+
+class MultiprocessInsertRunner:
+    """Run insert_embeddings across a pool of worker processes."""
+
+    def __init__(
+        self,
+        db: api.VectorDB,
+        dataset: DatasetManager,
+        normalize: bool,
+        workers: int,
+        filters: Filter = non_filter,
+        timeout: float | None = None,
+        queue_size: int | None = None,
+    ):
+        self.db = db
+        self.dataset = dataset
+        self.normalize = normalize
+        self.filters = filters
+        self.timeout = timeout if isinstance(timeout, int | float) else None
+
+        if workers <= 0:
+            workers = mp.cpu_count()
+        self.workers = workers
+        # A couple slots of slack per worker lets the producer run a step ahead
+        # without unbounded memory growth.
+        self.queue_size = queue_size if queue_size and queue_size > 0 else max(workers * 2, 4)
+
+    def _pull_labels(self, data_df: Any, ids: list[int]) -> list | None:
+        """Extract per-row scalar labels for StrEqual filter, if enabled."""
+        if self.filters.type != FilterOp.StrEqual:
+            return None
+        if self.dataset.data.scalar_labels_file_separated:
+            return self.dataset.scalar_labels[self.filters.label_field][ids].to_list()
+        return data_df[self.filters.label_field].tolist()
+
+    def _spawn_workers(
+        self,
+        ctx: Any,
+        task_queue: MPQueue,
+        error_queue: MPQueue,
+        counter: Synchronized,
+    ) -> list[mp.Process]:
+        procs: list[mp.Process] = []
+        for i in range(self.workers):
+            p = ctx.Process(
+                target=_insert_worker,
+                args=(self.db, task_queue, error_queue, counter, self.normalize, i),
+                name=f"vdb-load-{i}",
+                daemon=True,
+            )
+            p.start()
+            procs.append(p)
+        return procs
+
+    def _produce_batches(
+        self,
+        task_queue: MPQueue,
+        error_queue: MPQueue,
+        procs: list[mp.Process],
+        start: float,
+    ) -> int:
+        id_field = self.dataset.data.train_id_field
+        vec_field = self.dataset.data.train_vector_field
+        produced = 0
+        last_log = start
+
+        for data_df in self.dataset:
+            if self._abort_if_worker_died(error_queue, procs):
+                break
+
+            ids = data_df[id_field].tolist()
+            emb_np = np.stack(data_df[vec_field])
+            labels = self._pull_labels(data_df, ids)
+            self._put_with_interruptible_wait(
+                task_queue,
+                (ids, emb_np, labels),
+                procs,
+                start=start,
+                timeout=self.timeout,
+            )
+            produced += len(ids)
+
+            now = time.perf_counter()
+            if now - last_log >= _PROGRESS_INTERVAL_SEC:
+                log.info(f"Load progress: produced={produced} elapsed={now - start:.0f}s")
+                last_log = now
+
+            if self.timeout is not None and (now - start) > self.timeout:
+                log.warning(f"Multiprocess load exceeded timeout {self.timeout}s")
+                raise PerformanceTimeoutError
+
+        return produced
+
+    @time_it
+    def _run(self) -> int:
+        ctx = mp.get_context("spawn")
+        task_queue: MPQueue = ctx.Queue(maxsize=self.queue_size)
+        error_queue: MPQueue = ctx.Queue()
+        counter: Synchronized = ctx.Value("q", 0)
+
+        log.info(
+            f"Multiprocess load start: workers={self.workers}, "
+            f"queue_size={self.queue_size}, batch_size={config.NUM_PER_BATCH}",
+        )
+
+        procs = self._spawn_workers(ctx, task_queue, error_queue, counter)
+        start = time.perf_counter()
+        interrupted = False
+
+        try:
+            produced = self._produce_batches(task_queue, error_queue, procs, start)
+        except KeyboardInterrupt:
+            log.warning("Multiprocess load interrupted by user")
+            interrupted = True
+            raise
+        finally:
+            self._shutdown(procs, task_queue, graceful=not interrupted)
+
+        if not error_queue.empty():
+            err_detail = error_queue.get_nowait()
+            msg = f"Multiprocess load failed: {err_detail}"
+            raise RuntimeError(msg)
+
+        inserted = counter.value
+        elapsed = time.perf_counter() - start
+        rate = inserted / elapsed if elapsed > 0 else 0
+        log.info(
+            f"Multiprocess load done: produced={produced} inserted={inserted} "
+            f"elapsed={elapsed:.2f}s rate={rate:.0f}/s",
+        )
+        if inserted < produced:
+            msg = f"Partial load: only {inserted}/{produced} rows inserted"
+            raise RuntimeError(msg)
+        return inserted
+
+    @staticmethod
+    def _put_with_interruptible_wait(
+        queue: MPQueue,
+        item: Any,
+        procs: list[mp.Process],
+        chunk_timeout: float = 1.0,
+        start: float = 0.0,
+        timeout: float | None = None,
+    ) -> None:
+        """`queue.put` that polls so a Ctrl+C, worker crash, or timeout doesn't block forever."""
+        while True:
+            if timeout is not None and (time.perf_counter() - start) > timeout:
+                log.warning(f"Multiprocess load exceeded timeout {timeout}s while waiting to enqueue")
+                raise PerformanceTimeoutError
+            try:
+                queue.put(item, timeout=chunk_timeout)
+            except Exception:
+                if all(not p.is_alive() for p in procs):
+                    msg = "All workers exited while producer was waiting to enqueue"
+                    raise RuntimeError(msg) from None
+            else:
+                return
+
+    @staticmethod
+    def _abort_if_worker_died(error_queue: MPQueue, procs: list[mp.Process]) -> bool:
+        """Surface worker failures or unexpected exits early."""
+        if not error_queue.empty():
+            return True
+        return any(not p.is_alive() and p.exitcode not in (None, 0) for p in procs)
+
+    @staticmethod
+    def _shutdown(
+        procs: list[mp.Process],
+        task_queue: MPQueue,
+        graceful: bool,
+        graceful_join: float = 10.0,
+        hard_join: float = 3.0,
+    ) -> None:
+        """Wind down workers. On interrupt, skip draining and terminate fast."""
+        if graceful:
+            # Let workers finish what's already queued, then exit on sentinel.
+            for _ in procs:
+                try:
+                    task_queue.put(_SENTINEL, timeout=5)
+                except Exception:
+                    break
+            for p in procs:
+                p.join(timeout=graceful_join)
+
+        # Anyone still alive gets terminated — includes the interrupted path.
+        for p in procs:
+            if p.is_alive():
+                if graceful:
+                    log.warning(f"worker {p.name} did not exit cleanly; terminating")
+                with contextlib.suppress(Exception):
+                    p.terminate()
+        for p in procs:
+            p.join(timeout=hard_join)
+            if p.is_alive():
+                with contextlib.suppress(Exception):
+                    p.kill()
+                p.join(timeout=1)
+
+    def run(self) -> int:
+        count, _ = self._run()
+        return count

--- a/vectordb_bench/backend/task_runner.py
+++ b/vectordb_bench/backend/task_runner.py
@@ -17,6 +17,7 @@ from .data_source import DatasetSource
 from .runner import (
     ConcurrentInsertRunner,
     MultiProcessingSearchRunner,
+    MultiprocessInsertRunner,
     ReadWriteRunner,
     SerialInsertRunner,
     SerialSearchRunner,
@@ -249,19 +250,46 @@ class CaseRunner(BaseModel):
     def _load_train_data(self):
         """Insert train data concurrently and get the insert_duration"""
         try:
-            runner = ConcurrentInsertRunner(
-                self.db,
-                self.ca.dataset,
-                self.normalize,
-                self.ca.filters,
-                self.ca.load_timeout,
-                max_workers=self.config.load_concurrency or None,
-            )
+            workers = self._pick_load_processes()
+            if workers > 0:
+                log.info(f"Using MultiprocessInsertRunner (workers={workers})")
+                runner = MultiprocessInsertRunner(
+                    db=self.db,
+                    dataset=self.ca.dataset,
+                    normalize=self.normalize,
+                    workers=workers,
+                    filters=self.ca.filters,
+                    timeout=self.ca.load_timeout,
+                )
+            else:
+                runner = ConcurrentInsertRunner(
+                    self.db,
+                    self.ca.dataset,
+                    self.normalize,
+                    self.ca.filters,
+                    self.ca.load_timeout,
+                    max_workers=self.config.load_concurrency or None,
+                )
             runner.run()
         except Exception as e:
             raise e from None
         finally:
             runner = None
+
+    def _pick_load_processes(self) -> int:
+        """Return worker count for multi-process loader, or 0 to use threaded loader."""
+        if self.config.load_processes > 0:
+            return self.config.load_processes
+
+        if not getattr(self.db, "thread_safe", True) and self.config.load_concurrency > 1:
+            log.info(
+                f"{self.db.name} declares thread_safe=False; auto-switching to "
+                f"multi-process loader with {self.config.load_concurrency} workers "
+                f"(set --load-processes to override)",
+            )
+            return self.config.load_concurrency
+
+        return 0
 
     def _serial_search(self) -> tuple[float, float, float, float]:
         """Performance serial tests, search the entire test data once,

--- a/vectordb_bench/cli/cli.py
+++ b/vectordb_bench/cli/cli.py
@@ -240,6 +240,23 @@ class CommonTypedDict(TypedDict):
             help="Number of concurrent workers for data loading in performance cases (0 = cpu_count)",
         ),
     ]
+    load_processes: Annotated[
+        int,
+        click.option(
+            "--load-processes",
+            type=int,
+            default=0,
+            show_default=True,
+            help=(
+                "Use an N-worker multi-process loader instead of the threaded "
+                "one (--load-concurrency). 0 disables it. Recommended for "
+                "SQL-based vector DBs (OceanBase / TiDB / pgvector / Doris / "
+                "VectorChord) where the insert path is GIL-bound. When a client "
+                "declares thread_safe=False, this is auto-enabled with "
+                "--load-concurrency workers even if this flag is 0"
+            ),
+        ),
+    ]
     search_serial: Annotated[
         bool,
         click.option(
@@ -653,6 +670,7 @@ def run(
             parameters["search_concurrent"],
         ),
         load_concurrency=parameters["load_concurrency"],
+        load_processes=parameters["load_processes"],
     )
     task_label = parameters["task_label"]
 

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -244,6 +244,7 @@ class TaskConfig(BaseModel):
     case_config: CaseConfig
     stages: list[TaskStage] = ALL_TASK_STAGES
     load_concurrency: int = config.LOAD_CONCURRENCY
+    load_processes: int = 0
 
     @property
     def db_name(self):


### PR DESCRIPTION
Hi, thanks for the detailed review on #769! I've split the PR as suggested and addressed all three bugs you identified (partial load detection, timeout enforcement in queue wait, and PerformanceTimeoutError signature).

## Summary
- Add `MultiprocessInsertRunner` for parallel data loading across worker processes
- Add `--load-processes` CLI option for explicit multi-process control
- Auto-switch to multi-process loader when a client declares `thread_safe=False` and `--load-concurrency > 1`
- OceanBase: declare `thread_safe=False` with pickle support
- Improve `concurrent_runner` log message for `thread_safe=False` fallback

## On benchmark fairness

Great point on fairness — I've been thinking about this too. One thing I noticed is that SQL-based clients (OceanBase, PgVector, VectorChord, Doris, SeekDB) currently fall back to `max_workers=1` due to `thread_safe=False`, while thread-safe clients like Milvus and Elasticsearch can take advantage of multi-threaded loading. So it seems like there's already some difference in load parallelism across databases today.

The multi-process loader is an attempt to help bridge that gap. It's designed to be opt-in — only activated via explicit `--load-processes` or when `thread_safe=False` combined with `--load-concurrency > 1`. Default behavior stays the same for all existing clients.

Of course, I totally understand if you'd prefer a more conservative approach — for example, making it strictly explicit with no auto-switch at all. Would love to hear what you think works best for the project!
