### PR TITLE
feat: add VolcanoMilvus DISKANN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ All the database client supported
 
 | Optional database client | install command                             |
 |--------------------------|---------------------------------------------|
-| pymilvus, zilliz_cloud (*default*)     | `pip install vectordb-bench`                |
+| pymilvus, zilliz_cloud, volcanomilvus (*default*)     | `pip install vectordb-bench`                |
 | qdrant                   | `pip install vectordb-bench[qdrant]`        |
 | pinecone                 | `pip install vectordb-bench[pinecone]`      |
 | weaviate                 | `pip install vectordb-bench[weaviate]`      |

--- a/tests/test_volcano_milvus.py
+++ b/tests/test_volcano_milvus.py
@@ -1,0 +1,100 @@
+import pytest
+from click.testing import CliRunner
+
+from vectordb_bench.backend.clients import DB
+from vectordb_bench.backend.clients.api import IndexType
+from vectordb_bench.backend.clients.volcano_milvus import cli as volcano_milvus_cli
+from vectordb_bench.frontend.config.dbCaseConfigs import (
+    VolcanoMilvusLoadConfig,
+    VolcanoMilvusPerformanceConfig,
+)
+from vectordb_bench.models import CaseConfigParamType
+
+
+def test_volcano_milvus_diskann_load_param_contains_enable_prefetch():
+    """enable_prefetch is a collection-load knob (knowhere.enable_prefetch),
+    it must be emitted by load_param() and must NOT leak into search_param()."""
+    config_cls = DB.VolcanoMilvus.case_config_cls(index_type=IndexType.DISKANN)
+
+    case_config = config_cls(search_list=200, enable_prefetch=True)
+
+    assert case_config.load_param()["knowhere.enable_prefetch"] == "true"
+    assert case_config.search_param()["params"] == {"search_list": 200}
+
+
+def test_volcano_milvus_frontend_exposes_enable_prefetch():
+    load_labels = [config.label for config in VolcanoMilvusLoadConfig]
+    performance_labels = [config.label for config in VolcanoMilvusPerformanceConfig]
+
+    assert CaseConfigParamType.enable_prefetch in load_labels
+    assert CaseConfigParamType.enable_prefetch in performance_labels
+
+
+def test_volcano_milvus_cli_passes_enable_prefetch(monkeypatch: pytest.MonkeyPatch):
+    captured = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(volcano_milvus_cli, "run", fake_run)
+
+    volcano_milvus_cli.VolcanoMilvusDISKANN.callback(
+        db_label="test-volcano",
+        uri="http://localhost:19530",
+        user_name=None,
+        password=None,
+        num_shards=1,
+        replica_number=1,
+        load_reqs_size=int(1.5 * 1024 * 1024),
+        load_after_compaction=False,
+        search_list=200,
+        build_search_list=200,
+        max_degree=56,
+        legacy=False,
+        store_strategy="MEMORY",
+        quant_type="RABITQ",
+        num_threads=4,
+        distance_strategy="QUANT THEN MORE BITS",
+        enable_prefetch=True,
+        enable_thp=False,
+    )
+
+    assert captured["db_case_config"].enable_prefetch is True
+
+
+def test_volcano_milvus_click_flag_parses_enable_prefetch(monkeypatch: pytest.MonkeyPatch):
+    captured = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(volcano_milvus_cli, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        volcano_milvus_cli.VolcanoMilvusDISKANN,
+        ["--uri", "http://localhost:19530", "--enable-prefetch"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["db_case_config"].enable_prefetch is True
+
+
+def test_volcano_milvus_load_config_no_search_list():
+    """search_list is a query-time param, must not appear in load config."""
+    load_labels = [config.label for config in VolcanoMilvusLoadConfig]
+    assert CaseConfigParamType.SearchList not in load_labels
+
+
+def test_volcano_milvus_performance_has_build_search_list():
+    """Performance/Streaming case also triggers index build, build_search_list
+    must be tunable there as well."""
+    performance_labels = [config.label for config in VolcanoMilvusPerformanceConfig]
+    assert CaseConfigParamType.BuildSearchList in performance_labels
+
+
+def test_volcano_milvus_only_diskann_supported():
+    """Non-DISKANN index types should not silently fall back to upstream Milvus."""
+    assert DB.VolcanoMilvus.case_config_cls(index_type=IndexType.DISKANN) is not None
+    assert DB.VolcanoMilvus.case_config_cls(index_type=IndexType.HNSW) is None
+    assert DB.VolcanoMilvus.case_config_cls(index_type=IndexType.IVFFlat) is None

--- a/vectordb_bench/backend/clients/__init__.py
+++ b/vectordb_bench/backend/clients/__init__.py
@@ -63,6 +63,7 @@ class DB(Enum):
     PolarDB = "PolarDB"
     Pinot = "Pinot"
     SeekDB = "SeekDB"
+    VolcanoMilvus = "VolcanoMilvus"
 
     @property
     def init_cls(self) -> type[VectorDB]:  # noqa: PLR0911, PLR0912, C901, PLR0915
@@ -263,6 +264,11 @@ class DB(Enum):
             from .pinot.pinot import Pinot
 
             return Pinot
+
+        if self == DB.VolcanoMilvus:
+            from .volcano_milvus.volcano_milvus import VolcanoMilvus
+
+            return VolcanoMilvus
 
         if self == DB.SeekDB:
             from .seekdb.seekdb import SeekDB
@@ -472,6 +478,11 @@ class DB(Enum):
 
             return PinotConfig
 
+        if self == DB.VolcanoMilvus:
+            from .volcano_milvus.config import VolcanoMilvusConfig
+
+            return VolcanoMilvusConfig
+
         if self == DB.SeekDB:
             from .seekdb.config import SeekDBConfig
 
@@ -661,6 +672,11 @@ class DB(Enum):
                 IndexType.IVFFlat: PinotIVFFlatConfig,
                 IndexType.IVFPQ: PinotIVFPQConfig,
             }.get(index_type, PinotHNSWConfig)
+
+        if self == DB.VolcanoMilvus:
+            from .volcano_milvus.config import _volcano_milvus_case_config
+
+            return _volcano_milvus_case_config.get(index_type)
 
         if self == DB.SeekDB:
             from .seekdb.config import _seekdb_case_config

--- a/vectordb_bench/backend/clients/volcano_milvus/cli.py
+++ b/vectordb_bench/backend/clients/volcano_milvus/cli.py
@@ -1,0 +1,190 @@
+from typing import Annotated, Unpack
+
+import click
+from pydantic import SecretStr
+
+from vectordb_bench.backend.clients import DB
+from vectordb_bench.cli.cli import (
+    CommonTypedDict,
+    cli,
+    click_parameter_decorators_from_typed_dict,
+    run,
+)
+
+from ..milvus.cli import MilvusTypedDict
+
+DBTYPE = DB.VolcanoMilvus
+
+
+class VolcanoMilvusTypedDict(MilvusTypedDict):
+    load_reqs_size: Annotated[
+        int,
+        click.option(
+            "--load-reqs-size",
+            type=int,
+            help="Max request payload size (bytes) used to compute insert batch size",
+            required=False,
+            default=int(1.5 * 1024 * 1024),
+            show_default=True,
+        ),
+    ]
+    load_after_compaction: Annotated[
+        bool,
+        click.option(
+            "--load-after-compaction/--no-load-after-compaction",
+            "load_after_compaction",
+            help=(
+                "If True, defer load_collection until after compaction & index build in optimize(); "
+                "if False (default), load_collection right after collection creation and call "
+                "refresh_load at the end of optimize()."
+            ),
+            default=False,
+            show_default=True,
+        ),
+    ]
+
+
+class VolcanoMilvusDISKANNTypedDict(CommonTypedDict, VolcanoMilvusTypedDict):
+    max_degree: Annotated[
+        int,
+        click.option(
+            "--max-degree",
+            type=int,
+            help="R (max degree)",
+            required=False,
+            default=56,
+            show_default=True,
+        ),
+    ]
+    search_list: Annotated[
+        int,
+        click.option(
+            "--search-list",
+            type=int,
+            help="L (search list size)  used during DISKANN index search",
+            required=False,
+            default=200,
+            show_default=True,
+        ),
+    ]
+    build_search_list: Annotated[
+        int,
+        click.option(
+            "--build-search-list",
+            type=int,
+            help="L (search list size) used during DISKANN index build",
+            required=False,
+            default=200,
+            show_default=True,
+        ),
+    ]
+    legacy: Annotated[
+        bool,
+        click.option(
+            "--legacy/--no-legacy",
+            "legacy",
+            help="Use legacy Volcano DISKANN behavior",
+            default=False,
+            show_default=True,
+        ),
+    ]
+    store_strategy: Annotated[
+        str,
+        click.option(
+            "--store-strategy",
+            type=click.Choice(["MEMORY", "DISK"], case_sensitive=False),
+            help="Volcano store strategy",
+            required=False,
+            default="MEMORY",
+            show_default=True,
+        ),
+    ]
+    quant_type: Annotated[
+        str,
+        click.option(
+            "--quant-type",
+            type=click.Choice(["RABITQ", "PQ"], case_sensitive=False),
+            help="Volcano quant type",
+            required=False,
+            default="RABITQ",
+            show_default=True,
+        ),
+    ]
+    num_threads: Annotated[
+        int,
+        click.option(
+            "--num-threads",
+            type=int,
+            help="Degree of parallelism",
+            required=False,
+            default=4,
+            show_default=True,
+        ),
+    ]
+    distance_strategy: Annotated[
+        str,
+        click.option(
+            "--distance-strategy",
+            type=click.Choice(
+                ["FULL", "SINGLE QUANT", "QUANT THEN FULL", "QUANT THEN MORE BITS"],
+                case_sensitive=False,
+            ),
+            help="Volcano distance strategy",
+            required=False,
+            default="QUANT THEN MORE BITS",
+            show_default=True,
+        ),
+    ]
+    enable_prefetch: Annotated[
+        bool,
+        click.option(
+            "--enable-prefetch/--disable-prefetch",
+            "enable_prefetch",
+            help="Enable Volcano DISKANN prefetch during search",
+            default=False,
+            show_default=True,
+        ),
+    ]
+    enable_thp: Annotated[
+        bool,
+        click.option(
+            "--enable-thp/--disable-thp",
+            "enable_thp",
+            help="Enable Volcano DISKANN transparent huge pages on collection load",
+            default=False,
+            show_default=True,
+        ),
+    ]
+
+
+@cli.command(name="volcanomilvusdiskann")
+@click_parameter_decorators_from_typed_dict(VolcanoMilvusDISKANNTypedDict)
+def VolcanoMilvusDISKANN(**parameters: Unpack[VolcanoMilvusDISKANNTypedDict]):
+    from .config import VolcanoMilvusConfig, VolcanoMilvusDISKANNConfig
+
+    run(
+        db=DBTYPE,
+        db_config=VolcanoMilvusConfig(
+            db_label=parameters["db_label"],
+            uri=SecretStr(parameters["uri"]),
+            user=parameters["user_name"],
+            password=SecretStr(parameters["password"]) if parameters["password"] else None,
+            num_shards=int(parameters["num_shards"]),
+            replica_number=int(parameters["replica_number"]),
+            load_reqs_size=int(parameters["load_reqs_size"]),
+            load_after_compaction=bool(parameters["load_after_compaction"]),
+        ),
+        db_case_config=VolcanoMilvusDISKANNConfig(
+            search_list=parameters["search_list"],
+            build_search_list=parameters["build_search_list"],
+            max_degree=parameters["max_degree"],
+            legacy=parameters["legacy"],
+            store_strategy=parameters["store_strategy"],
+            quant_type=parameters["quant_type"],
+            num_threads=parameters["num_threads"],
+            distance_strategy=parameters["distance_strategy"],
+            enable_prefetch=bool(parameters["enable_prefetch"]),
+            enable_thp=bool(parameters["enable_thp"]),
+        ),
+        **parameters,
+    )

--- a/vectordb_bench/backend/clients/volcano_milvus/config.py
+++ b/vectordb_bench/backend/clients/volcano_milvus/config.py
@@ -1,0 +1,98 @@
+from typing import ClassVar
+
+from pydantic import SecretStr
+
+from ..api import DBCaseConfig, DBConfig, IndexType, MetricType
+from ..milvus.config import DISKANNConfig, MilvusIndexConfig
+
+
+class VolcanoMilvusConfig(DBConfig):
+    _extra_empty_skip: ClassVar[frozenset[str]] = frozenset({"user", "password"})
+
+    uri: SecretStr = SecretStr("http://localhost:19530")
+    user: str | None = None
+    password: SecretStr | None = None
+    num_shards: int = 1
+    replica_number: int = 1
+    # Tuning knobs for load performance
+    load_reqs_size: int = int(1.5 * 1024 * 1024)
+    # Controls when load_collection runs:
+    # - False (default): load immediately after collection creation, then refresh_load in optimize().
+    # - True: defer load until after compaction and index build in optimize().
+    load_after_compaction: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "uri": self.uri.get_secret_value(),
+            "user": self.user if self.user else None,
+            "password": self.password.get_secret_value() if self.password else None,
+            "num_shards": self.num_shards,
+            "replica_number": self.replica_number,
+            "load_reqs_size": self.load_reqs_size,
+            "load_after_compaction": self.load_after_compaction,
+        }
+
+
+class VolcanoMilvusDISKANNConfig(DISKANNConfig):
+    """VolcanoMilvus DISKANN index config.
+
+    Inherits from Milvus ``DISKANNConfig`` and adds Volcano-specific fields.
+    Override ``index_param`` / ``search_param`` to inject Volcano-specific
+    entries into ``params`` while keeping the original contract.
+    """
+
+    max_degree: int = 48
+    legacy: bool = False
+    store_strategy: str = "MEMORY"
+    quant_type: str = "RABITQ"
+    num_threads: int = 4
+    distance_strategy: str = "QUANT THEN MORE BITS"
+    enable_prefetch: bool = False
+    enable_thp: bool = False
+    build_search_list: int = 200
+
+    def parse_metric(self) -> str:
+        if not self.metric_type:
+            return ""
+
+        if self.metric_type == MetricType.COSINE:
+            return MetricType.L2.value
+        return self.metric_type.value
+
+    def index_param(self) -> dict:
+        extra_params: dict = {
+            "max_degree": self.max_degree,
+            "legacy": self.legacy,
+            "store_strategy": self.store_strategy,
+            "quant_type": self.quant_type,
+            "num_threads": self.num_threads,
+            "distance_strategy": self.distance_strategy,
+            "search_list_size": self.build_search_list,
+        }
+        return {
+            "metric_type": self.parse_metric(),
+            "index_type": self.index.value,
+            "params": extra_params,
+        }
+
+    def load_param(self) -> dict:
+        return {
+            "knowhere.enable_thp": str(self.enable_thp).lower(),
+            "knowhere.enable_prefetch": str(self.enable_prefetch).lower(),
+        }
+
+
+# Only DISKANN is supported by VolcanoMilvus today. Other index types are not
+# exposed here so callers fail fast (case_config_cls returns None) instead of
+# silently using the upstream Milvus index implementation.
+_volcano_milvus_case_config: dict[IndexType, type[DBCaseConfig]] = {
+    IndexType.DISKANN: VolcanoMilvusDISKANNConfig,
+}
+
+
+__all__ = [
+    "MilvusIndexConfig",
+    "VolcanoMilvusConfig",
+    "VolcanoMilvusDISKANNConfig",
+    "_volcano_milvus_case_config",
+]

--- a/vectordb_bench/backend/clients/volcano_milvus/volcano_milvus.py
+++ b/vectordb_bench/backend/clients/volcano_milvus/volcano_milvus.py
@@ -1,0 +1,200 @@
+"""VolcanoMilvus client implementation.
+
+Extends the base Milvus client with Volcano-specific behaviors:
+- Expose ``load_reqs_size`` to tune insert batch size (avoid gRPC payload limits).
+- Expose ``load_after_compaction`` to choose collection load timing:
+  - ``False`` (default): ``load_collection`` is called right after collection creation;
+    ``optimize()`` ends with ``refresh_load``.
+  - ``True``: ``load_collection`` is deferred until after compaction & index wait
+    in ``optimize()``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pymilvus import DataType, MilvusClient
+
+from ..milvus.milvus import MILVUS_FORCE_MERGE_TARGET_SIZE_MB, MILVUS_LOAD_REQS_SIZE, Milvus
+
+if TYPE_CHECKING:
+    from .config import MilvusIndexConfig
+
+log = logging.getLogger(__name__)
+
+
+class VolcanoMilvus(Milvus):
+    # Insert concurrency is handled by the framework (ConcurrentInsertRunner).
+    # This client does not manage its own multiprocessing pool.
+    thread_safe: bool = True
+
+    def __init__(
+        self,
+        dim: int,
+        db_config: dict,
+        db_case_config: MilvusIndexConfig,
+        collection_name: str = "VDBBench",
+        drop_old: bool = False,
+        name: str = "VolcanoMilvus",
+        with_scalar_labels: bool = False,
+        **kwargs,
+    ):
+        """Initialize wrapper around the volcano milvus vector database.
+
+        The vector index is created right after collection creation (same as the
+        base ``Milvus`` client). Whether ``load_collection`` is called here or
+        deferred to ``optimize()`` is controlled by ``load_after_compaction``.
+        """
+        self.name = name
+        self.db_config = db_config
+        self.case_config = db_case_config
+        self.collection_name = collection_name
+        self.load_reqs_size = int(self.db_config.get("load_reqs_size", MILVUS_LOAD_REQS_SIZE))
+        self.batch_size = max(1, int(self.load_reqs_size / (dim * 4)))
+        self.with_scalar_labels = with_scalar_labels
+        self.load_after_compaction = bool(self.db_config.get("load_after_compaction", False))
+
+        self._primary_field = "pk"
+        self._scalar_id_field = "id"
+        self._scalar_label_field = "label"
+        self._scalar_payload_label_field = self._scalar_label_field
+        self._multitenant_partition_key_field = self._scalar_label_field
+        self.multitenant_tenant_labels: list[str] = kwargs.get("multitenant_tenant_labels", [])
+        if self.multitenant_tenant_labels:
+            self._multitenant_partition_key_field = "labels"
+            if self.with_scalar_labels:
+                self._scalar_payload_label_field = "scalar_label"
+        self._vector_field = "vector"
+        self._vector_index_name = "vector_idx"
+        self._scalar_id_index_name = "id_sort_idx"
+        self._scalar_labels_index_name = "labels_idx"
+
+        client = MilvusClient(
+            uri=self.db_config.get("uri"),
+            user=self.db_config.get("user"),
+            password=self.db_config.get("password"),
+            # VolcanoMilvusConfig does not expose `token` (Volcano uses uri/user/password
+            # auth). Pass through `db_config["token"]` if a future config adds it; default
+            # to "" to stay compatible with the upstream Milvus client signature.
+            token=self.db_config.get("token", ""),
+            timeout=30,
+        )
+
+        if drop_old and client.has_collection(self.collection_name):
+            log.info(f"{self.name} client drop_old collection: {self.collection_name}")
+            client.drop_collection(self.collection_name)
+
+        if not client.has_collection(self.collection_name):
+            schema = MilvusClient.create_schema()
+            schema.add_field(self._primary_field, DataType.INT64, is_primary=True)
+            schema.add_field(self._scalar_id_field, DataType.INT64)
+            schema.add_field(self._vector_field, DataType.FLOAT_VECTOR, dim=dim)
+
+            if self.multitenant_tenant_labels:
+                schema.add_field(
+                    self._multitenant_partition_key_field,
+                    DataType.VARCHAR,
+                    max_length=256,
+                    is_partition_key=True,
+                )
+
+            if self.with_scalar_labels:
+                is_partition_key = db_case_config.use_partition_key
+                log.info(f"with_scalar_labels, add a new varchar field, as partition_key: {is_partition_key}")
+                if not self.multitenant_tenant_labels or (
+                    self._scalar_payload_label_field != self._multitenant_partition_key_field
+                ):
+                    schema.add_field(
+                        self._scalar_payload_label_field,
+                        DataType.VARCHAR,
+                        max_length=256,
+                        is_partition_key=is_partition_key and not self.multitenant_tenant_labels,
+                    )
+
+            log.info(f"{self.name} create collection: {self.collection_name}")
+
+            index_params = self._build_index_params()
+            client.create_collection(
+                collection_name=self.collection_name,
+                schema=schema,
+                num_shards=self.db_config.get("num_shards", 1),
+                consistency_level="Session",
+            )
+            client.create_index(self.collection_name, index_params)
+            if not self.load_after_compaction:
+                self._apply_load_with_properties(client)
+
+        client.close()
+
+    def need_normalize_cosine(self) -> bool:
+        """Wheather this database need to normalize dataset to support COSINE"""
+        log.info("cosine dataset need normalize.")
+        return True
+
+    def _apply_load_with_properties(self, client: MilvusClient) -> None:
+        """Apply Volcano-specific knowhere.* properties and load the collection.
+
+        The properties (currently ``knowhere.enable_thp`` / ``knowhere.enable_prefetch``)
+        have to be set via ``alter_collection_properties`` before ``load_collection``
+        so the segment loader picks them up. We keep the alter+load pair in one helper
+        to make the intent explicit and avoid name-shadowing with
+        ``MilvusClient.load_collection``.
+        """
+        properties = self.case_config.load_param()
+        if properties:
+            client.alter_collection_properties(
+                collection_name=self.collection_name,
+                properties=properties,
+            )
+
+        collection_properties = client.describe_collection(self.collection_name).get("properties")
+        log.info(f"set collection properties to: {collection_properties}")
+
+        client.load_collection(
+            self.collection_name,
+            replica_number=self.db_config.get("replica_number", 1),
+        )
+
+    def _optimize(self):
+        """Volcano-specific optimize.
+
+        Overrides the parent ``_optimize`` to control collection-load timing:
+          - ``load_after_compaction=True``: collection is loaded here (after compaction
+            and index wait) via ``_apply_load_with_properties``;
+          - ``load_after_compaction=False`` (default): collection was already loaded in
+            ``__init__``, so we end with ``refresh_load`` like the upstream Milvus.
+
+        Otherwise mirrors the upstream control flow (flush -> wait segments sorted ->
+        wait index -> compact -> wait compaction -> wait index again), including the
+        ``is_gpu_index`` skip branch and the ``PERMISSION_DENIED`` fallback.
+        """
+        log.info(f"{self.name} optimizing before search")
+        try:
+            self.client.flush(self.collection_name)
+
+            try:
+                self._wait_for_segments_sorted()
+                compaction_id = self.client.compact(
+                    self.collection_name,
+                    target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB,
+                )
+                if compaction_id > 0:
+                    self._wait_for_compaction(compaction_id)
+                log.info(f"{self.name} force merge compaction completed.")
+            except Exception as e:
+                log.warning(f"{self.name} compact or list segments error: {e}")
+                if getattr(getattr(e, "code", None), "name", None) == "PERMISSION_DENIED":
+                    log.warning("Skip compact due to list segments or compact permission denied.")
+                else:
+                    raise e from None
+
+            # wait for index no matter what
+            self._wait_for_index()
+            if self.load_after_compaction:
+                self._apply_load_with_properties(self.client)
+            else:
+                self.client.refresh_load(self.collection_name)
+        except Exception as e:
+            log.warning(f"{self.name} optimize error: {e}")
+            raise e from None

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -42,6 +42,7 @@ from ..backend.clients.tidb.cli import TiDB
 from ..backend.clients.turbopuffer.cli import TurboPuffer, TurboPufferUnpin
 from ..backend.clients.vectorchord.cli import VectorChordGraph, VectorChordRQ
 from ..backend.clients.vespa.cli import Vespa
+from ..backend.clients.volcano_milvus.cli import VolcanoMilvusDISKANN
 from ..backend.clients.weaviate_cloud.cli import Weaviate
 from ..backend.clients.zilliz_cloud.cli import ZillizAutoIndex
 from ..backend.clients.zvec.cli import Zvec
@@ -98,6 +99,7 @@ cli.add_command(PolarDBHNSWFlat)
 cli.add_command(PolarDBHNSWPQ)
 cli.add_command(PolarDBHNSWSQ)
 cli.add_command(SeekDBHNSW)
+cli.add_command(VolcanoMilvusDISKANN)
 
 
 if __name__ == "__main__":

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -2168,6 +2168,124 @@ MilvusPerformanceConfig = [
     CaseConfigParamInput_Milvus_use_partition_key,
 ]
 
+# ---- VolcanoMilvus ----
+# Reuse Milvus UI configs for all index types except DISKANN, where
+# Volcano-specific parameters are shown in addition to Milvus's SearchList.
+# Append Volcano-specific CaseConfigInput items below when adding new fields
+# to VolcanoMilvusDISKANNConfig.
+
+CaseConfigParamInput_IndexType_VolcanoMilvus = CaseConfigInput(
+    label=CaseConfigParamType.IndexType,
+    inputType=InputType.Option,
+    inputHelp="VolcanoMilvus currently supports DISKANN only",
+    inputConfig={
+        "options": [IndexType.DISKANN.value],
+    },
+)
+
+CaseConfigParamInput_Volcano_max_degree = CaseConfigInput(
+    label=CaseConfigParamType.max_degree,
+    inputType=InputType.Number,
+    inputConfig={"min": 1, "max": 65536, "value": 56},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_legacy = CaseConfigInput(
+    label=CaseConfigParamType.legacy,
+    inputType=InputType.Bool,
+    displayLabel="Legacy",
+    inputHelp="Use legacy Volcano DISKANN behavior",
+    inputConfig={"value": False},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_store_strategy = CaseConfigInput(
+    label=CaseConfigParamType.store_strategy,
+    inputType=InputType.Option,
+    inputConfig={"options": ["MEMORY", "DISK"], "value": "MEMORY"},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_quant_type = CaseConfigInput(
+    label=CaseConfigParamType.quant_type,
+    inputType=InputType.Option,
+    inputConfig={"options": ["RABITQ", "PQ"], "value": "RABITQ"},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_num_threads = CaseConfigInput(
+    label=CaseConfigParamType.num_threads,
+    inputType=InputType.Number,
+    inputConfig={"min": 1, "max": 1024, "value": 4},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_distance_strategy = CaseConfigInput(
+    label=CaseConfigParamType.distance_strategy,
+    inputType=InputType.Option,
+    inputConfig={
+        "options": ["FULL", "SINGLE QUANT", "QUANT THEN FULL", "QUANT THEN MORE BITS"],
+        "value": "QUANT THEN MORE BITS",
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_enable_prefetch = CaseConfigInput(
+    label=CaseConfigParamType.enable_prefetch,
+    inputType=InputType.Bool,
+    displayLabel="Enable Prefetch",
+    inputHelp="Enable Volcano DISKANN prefetch during search",
+    inputConfig={"value": False},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_enable_thp = CaseConfigInput(
+    label=CaseConfigParamType.enable_thp,
+    inputType=InputType.Bool,
+    displayLabel="Enable THP",
+    inputHelp="Enable Volcano DISKANN transparent huge pages on collection load",
+    inputConfig={"value": False},
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+CaseConfigParamInput_Volcano_BuildSearchList = CaseConfigInput(
+    label=CaseConfigParamType.BuildSearchList,
+    inputType=InputType.Number,
+    inputConfig={
+        "min": 1,
+        "max": MAX_STREAMLIT_INT,
+        "value": 200,
+    },
+    isDisplayed=lambda config: config.get(CaseConfigParamType.IndexType, None) == IndexType.DISKANN.value,
+)
+
+VolcanoMilvusLoadConfig = [
+    CaseConfigParamInput_IndexType_VolcanoMilvus,
+    *MilvusLoadConfig[1:],
+    CaseConfigParamInput_Volcano_max_degree,
+    CaseConfigParamInput_Volcano_legacy,
+    CaseConfigParamInput_Volcano_store_strategy,
+    CaseConfigParamInput_Volcano_quant_type,
+    CaseConfigParamInput_Volcano_num_threads,
+    CaseConfigParamInput_Volcano_distance_strategy,
+    CaseConfigParamInput_Volcano_enable_prefetch,
+    CaseConfigParamInput_Volcano_enable_thp,
+    CaseConfigParamInput_Volcano_BuildSearchList,
+]
+VolcanoMilvusPerformanceConfig = [
+    CaseConfigParamInput_IndexType_VolcanoMilvus,
+    *MilvusPerformanceConfig[1:],
+    CaseConfigParamInput_Volcano_max_degree,
+    CaseConfigParamInput_Volcano_legacy,
+    CaseConfigParamInput_Volcano_store_strategy,
+    CaseConfigParamInput_Volcano_quant_type,
+    CaseConfigParamInput_Volcano_num_threads,
+    CaseConfigParamInput_Volcano_distance_strategy,
+    CaseConfigParamInput_Volcano_enable_prefetch,
+    CaseConfigParamInput_Volcano_enable_thp,
+    CaseConfigParamInput_Volcano_BuildSearchList,
+]
+
 WeaviateLoadConfig = [
     CaseConfigParamInput_MaxConnections,
     CaseConfigParamInput_EFConstruction_Weaviate,
@@ -3063,6 +3181,11 @@ CASE_CONFIG_MAP = {
     DB.PolarDB: {
         CaseLabel.Load: PolarDBConfig,
         CaseLabel.Performance: PolarDBConfig,
+    },
+    DB.VolcanoMilvus: {
+        CaseLabel.Load: VolcanoMilvusLoadConfig,
+        CaseLabel.Performance: VolcanoMilvusPerformanceConfig,
+        CaseLabel.Streaming: VolcanoMilvusPerformanceConfig,
     },
 }
 

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -51,6 +51,7 @@ class CaseConfigParamType(Enum):
     ef_construction = "ef_construction"
     EF = "ef"
     SearchList = "search_list"
+    BuildSearchList = "build_search_list"
     ef_search = "ef_search"
     Nlist = "nlist"
     Nprobe = "nprobe"
@@ -137,6 +138,16 @@ class CaseConfigParamType(Enum):
     oversample_factor = "oversample_factor"
     confidence_interval = "confidence_interval"
     clip = "clip"
+
+    # Volcano parameters
+    max_degree = "max_degree"
+    legacy = "legacy"
+    store_strategy = "store_strategy"
+    quant_type = "quant_type"
+    num_threads = "num_threads"
+    distance_strategy = "distance_strategy"
+    enable_prefetch = "enable_prefetch"
+    enable_thp = "enable_thp"
 
     # OceanBase IVF parameters
     sample_per_nlist = "sample_per_nlist"


### PR DESCRIPTION
## Summary

  Add VolcanoMilvus as a new VectorDBBench target by extending the existing Milvus client with Volcano-specific DISKANN behavior.

  ## What's added

  - New VolcanoMilvus client implementation under vectordb_bench/backend/clients/volcano_milvus/
  - New CLI command: vectordbbench volcanomilvusdiskann ...
  - Volcano DISKANN config support:
      - build params: max_degree, build_search_list, legacy, store_strategy, quant_type, num_threads, distance_strategy

  - Load behavior knobs: load_reqs_size and load_after_compaction
  - Frontend integration for Load, Performance, and Streaming benchmark cases
  - README/model enum updates so VolcanoMilvus is discoverable as a supported client
  - Unit tests for CLI parsing, frontend config exposure, load/search params, and DISKANN-only case mapping

  ## Supported index
 Only DISKANN is exposed for VolcanoMilvus in this change. Other index types do not fall back to the upstream Milvus configs silently.

  ## Example
```bash
vectordbbench volcanomilvusdiskann \
  --case-type Performance768D10M \
  --k 100 \
  --num-concurrency 400 \
  --uri <uri> \
  --user-name <user-name> \
  --password <pass> \
  --search-list 300 \
  --max-degree 48  \
  --replica-number 1 \
  --num-shards 1 \
  --load-after-compaction  \
  --distance-strategy "quant then full" \
  --num-threads 64 \
  --concurrency-duration 30 \
  --enable-thp 
  --enable-prefetch
```