### PR TITLE
fix(runner): add 10s cooldown between concurrent and serial search ph…

### DIFF
--- a/vectordb_bench/backend/task_runner.py
+++ b/vectordb_bench/backend/task_runner.py
@@ -318,6 +318,12 @@ class CaseRunner(BaseModel):
                         m.conc_latency_avg_list,
                     ) = search_results
                 if TaskStage.SEARCH_SERIAL in self.config.stages:
+                    if TaskStage.SEARCH_CONCURRENT in self.config.stages:
+                        cooldown = 10
+                        log.info(
+                            f"Cooldown {cooldown}s before serial search to ensure a stable measurement environment"
+                        )
+                        time.sleep(cooldown)
                     search_results = self._serial_search()
                     m.recall, m.ndcg, m.serial_latency_p99, m.serial_latency_p95 = search_results
             m.payload_profile = self.ca.payload_profile.value


### PR DESCRIPTION
…ases

The serial search phase measures single-query latency under idle conditions. Previously it launched immediately after the concurrent phase, while the end-to-end path may still be in a saturated state. This significantly affects the accuracy of serial latency, especially p99/p95, because the first few queries experience an environment similar to the concurrent test rather than the intended single-user condition.

---

This improves serial latency accuracy for **all database backends**.