### PR TITLE
解决自定义数据集只能输入一个train.parquet文件的问题

### DIFF
--- a/vectordb_bench/backend/dataset.py
+++ b/vectordb_bench/backend/dataset.py
@@ -130,6 +130,8 @@ class CustomDataset(BaseDataset):
 
     @property
     def train_files(self) -> list[str]:
+        if ("," not in self.train_file) and self.file_num > 1:
+            return utils.compose_train_files(self.file_num, self.use_shuffled)
         train_file = self.train_file
         prefix = f"{train_file}"
         train_files = []


### PR DESCRIPTION
修改后，对于自定义数据集，能输入多个train.parquet文件