### PR TITLE
fix(hologres): enable thread-safe concurrent inserts

### DIFF
--- a/vectordb_bench/backend/clients/hologres/hologres.py
+++ b/vectordb_bench/backend/clients/hologres/hologres.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import struct
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from io import StringIO
@@ -51,8 +52,7 @@ psycopg.adapters.register_dumper(HoloFloat4Array, HoloFloat4ArrayDumper)
 class Hologres(VectorDB):
     """Use psycopg instructions"""
 
-    conn: psycopg.Connection[Any] | None = None
-    cursor: psycopg.Cursor[Any] | None = None
+    thread_safe: bool = True  # each thread gets its own connection via threading.local()
 
     _tg_name: str = "vdb_bench_tg_1"
 
@@ -74,13 +74,20 @@ class Hologres(VectorDB):
         self._primary_field = "id"
         self._vector_field = "embedding"
 
-        # construct basic units
-        self.conn, self.cursor = self._create_connection(**self.db_config)
+        # Thread-local storage for per-thread connections (thread-safe concurrent inserts)
+        self._local = threading.local()
+        self._all_conns: list[psycopg.Connection[Any]] = []
+        self._conns_lock = threading.Lock()
+
+        # Temporary connection for setup, closed at end of __init__
+        conn, cursor = self._create_connection(**self.db_config)
+        self._local.conn = conn
+        self._local.cursor = cursor
 
         # create vector extension
         if self.case_config.is_proxima():
-            self.cursor.execute("CREATE EXTENSION proxima;")
-            self.conn.commit()
+            cursor.execute("CREATE EXTENSION proxima;")
+            conn.commit()
 
         log.info(f"{self.name} config values: {self.db_config}\n{self.case_config}")
         if not any(
@@ -102,10 +109,24 @@ class Hologres(VectorDB):
             if self.case_config.create_index_before_load:
                 self._create_index()
 
-        self.cursor.close()
-        self.conn.close()
-        self.cursor = None
-        self.conn = None
+        cursor.close()
+        conn.close()
+        self._local.cursor = None
+        self._local.conn = None
+
+    def __getstate__(self):
+        # Exclude unpicklable threading objects; recreated in __setstate__
+        state = self.__dict__.copy()
+        state.pop("_local", None)
+        state.pop("_conns_lock", None)
+        state.pop("_all_conns", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._local = threading.local()
+        self._conns_lock = threading.Lock()
+        self._all_conns = []
 
     @staticmethod
     def _create_connection(**kwargs) -> tuple[Connection, Cursor]:
@@ -118,18 +139,50 @@ class Hologres(VectorDB):
 
         return conn, cursor
 
+    def _get_conn(self) -> Connection:
+        """Return this thread's connection, creating one if needed."""
+        conn = getattr(self._local, "conn", None)
+        if conn is None or conn.closed:
+            conn, cursor = self._create_connection(**self.db_config)
+            self._local.conn = conn
+            self._local.cursor = cursor
+            self._set_search_guc_on(conn, cursor)
+            with self._conns_lock:
+                self._all_conns.append(conn)
+        return conn
+
+    def _get_cursor(self) -> Cursor:
+        """Return this thread's cursor, creating connection if needed."""
+        cursor = getattr(self._local, "cursor", None)
+        if cursor is None or cursor.closed:
+            self._get_conn()  # creates both conn and cursor
+            cursor = self._local.cursor
+        return cursor
+
+    def _set_search_guc_on(self, conn: Connection, cursor: Cursor) -> None:
+        """Set session-level search GUC on the given connection."""
+        sql_guc = sql.SQL(f"SET hg_vector_ef_search = {self.case_config.ef_search};")
+        log.info(f"{self.name} client set search guc: {sql_guc.as_string()}")
+        cursor.execute(sql_guc)
+        conn.commit()
+
+    def _set_search_guc(self) -> None:
+        """Set session-level search GUC on this thread's connection."""
+        self._set_search_guc_on(self._get_conn(), self._get_cursor())
+
     @contextmanager
     def init(self) -> Generator[None, None, None]:
-        """
-        Examples:
-            >>> with self.init():
-            >>>     self.insert_embeddings()
-            >>>     self.search_embedding()
-        """
+        """Open connection for calling thread, prepare for operations.
 
-        self.conn, self.cursor = self._create_connection(**self.db_config)
-
-        self._set_search_guc()
+        Worker threads lazily create their own connections via _get_conn().
+        On exit, closes all thread-local connections.
+        """
+        conn, cursor = self._create_connection(**self.db_config)
+        self._local.conn = conn
+        self._local.cursor = cursor
+        self._set_search_guc_on(conn, cursor)
+        with self._conns_lock:
+            self._all_conns.append(conn)
 
         self._search_query_no_filter = sql.SQL("""
             SELECT id
@@ -159,35 +212,30 @@ class Hologres(VectorDB):
         try:
             yield
         finally:
-            self.cursor.close()
-            self.conn.close()
-            self.cursor = None
-            self.conn = None
-
-    def _set_search_guc(self):
-        assert self.conn is not None, "Connection is not initialized"
-        assert self.cursor is not None, "Cursor is not initialized"
-
-        sql_guc = sql.SQL(f"SET hg_vector_ef_search = {self.case_config.ef_search};")
-        log.info(f"{self.name} client set search guc: {sql_guc.as_string()}")
-        self.cursor.execute(sql_guc)
-        self.conn.commit()
+            with self._conns_lock:
+                conns_to_close = list(self._all_conns)
+                self._all_conns.clear()
+            for c in conns_to_close:
+                if not c.closed:
+                    c.close()
+            self._local.conn = None
+            self._local.cursor = None
 
     def _drop_table(self):
-        assert self.conn is not None, "Connection is not initialized"
-        assert self.cursor is not None, "Cursor is not initialized"
+        conn = self._get_conn()
+        cursor = self._get_cursor()
 
         log.info(f"{self.name} client drop table : {self.table_name}")
-        self.cursor.execute(
+        cursor.execute(
             sql.SQL("DROP TABLE IF EXISTS {table_name};").format(
                 table_name=sql.Identifier(self.table_name),
             ),
         )
-        self.conn.commit()
+        conn.commit()
 
         try:
             log.info(f"{self.name} client purge table recycle bin: {self.table_name}")
-            self.cursor.execute(
+            cursor.execute(
                 sql.SQL("purge TABLE {table_name};").format(
                     table_name=sql.Identifier(self.table_name),
                 ),
@@ -195,23 +243,23 @@ class Hologres(VectorDB):
         except Exception as e:
             log.info(f"{self.name} client purge table {self.table_name} recycle bin failed, error: {e}, ignore.")
         finally:
-            self.conn.commit()
+            conn.commit()
 
         try:
             log.info(f"{self.name} client drop table group : {self._tg_name}")
-            self.cursor.execute(sql.SQL(f"CALL HG_DROP_TABLE_GROUP('{self._tg_name}');"))
+            cursor.execute(sql.SQL(f"CALL HG_DROP_TABLE_GROUP('{self._tg_name}');"))
         except Exception as e:
             log.info(f"{self.name} client drop table group : {self._tg_name} failed, error: {e}, ignore.")
         finally:
-            self.conn.commit()
+            conn.commit()
 
         try:
             log.info(f"{self.name} client free cache")
-            self.cursor.execute("select hg_admin_command('freecache');")
+            cursor.execute("select hg_admin_command('freecache');")
         except Exception as e:
             log.info(f"{self.name} client free cache failed, error: {e}, ignore.")
         finally:
-            self.conn.commit()
+            conn.commit()
 
     def optimize(self, data_size: int | None = None):
         if self.case_config.create_index_after_load:
@@ -220,12 +268,13 @@ class Hologres(VectorDB):
         self._analyze()
 
     def _vacuum(self):
+        conn = self._get_conn()
         log.info(f"{self.name} client vacuum table : {self.table_name}")
         try:
             # VACUUM cannot run inside a transaction block
             # it's better to new a connection
-            self.conn.autocommit = True
-            with self.conn.cursor() as cursor:
+            conn.autocommit = True
+            with conn.cursor() as cursor:
                 cursor.execute(
                     sql.SQL("""
                         VACUUM {table_name};
@@ -238,16 +287,18 @@ class Hologres(VectorDB):
             log.warning(f"Failed to vacuum table: {self.table_name} error: {e}")
             raise e from None
         finally:
-            self.conn.autocommit = True
+            conn.autocommit = True
 
     def _analyze(self):
+        cursor = self._get_cursor()
         log.info(f"{self.name} client analyze table : {self.table_name}")
-        self.cursor.execute(sql.SQL(f"ANALYZE {self.table_name};"))
+        cursor.execute(sql.SQL(f"ANALYZE {self.table_name};"))
         log.info(f"{self.name} client analyze table : {self.table_name} done")
 
     def _full_compact(self):
+        cursor = self._get_cursor()
         log.info(f"{self.name} client full compact table : {self.table_name}")
-        self.cursor.execute(
+        cursor.execute(
             sql.SQL("""
                 SELECT hologres.hg_full_compact_table(
                     '{table_name}',
@@ -261,8 +312,8 @@ class Hologres(VectorDB):
         log.info(f"{self.name} client full compact table : {self.table_name} done")
 
     def _create_index(self):
-        assert self.conn is not None, "Connection is not initialized"
-        assert self.cursor is not None, "Cursor is not initialized"
+        conn = self._get_conn()
+        cursor = self._get_cursor()
 
         sql_index = sql.SQL("""
             CALL set_table_property ('{table_name}', 'vectors', '{{
@@ -281,15 +332,15 @@ class Hologres(VectorDB):
 
         log.info(f"{self.name} client create index on table : {self.table_name}, with sql: {sql_index.as_string()}")
         try:
-            self.cursor.execute(sql_index)
-            self.conn.commit()
+            cursor.execute(sql_index)
+            conn.commit()
         except Exception as e:
             log.warning(f"Failed to create index on table: {self.table_name} error: {e}")
             raise e from None
 
     def _set_replica_count(self, replica_count: int = 2):
-        assert self.conn is not None, "Connection is not initialized"
-        assert self.cursor is not None, "Cursor is not initialized"
+        conn = self._get_conn()
+        cursor = self._get_cursor()
 
         try:
             # non-warehouse mode by default
@@ -300,13 +351,13 @@ class Hologres(VectorDB):
             # check warehouse mode
             sql_check = sql.SQL("select count(*) from hologres.hg_warehouses;")
             log.info(f"check warehouse mode with sql: {sql_check}")
-            self.cursor.execute(sql_check)
-            result_check = self.cursor.fetchone()[0]
+            cursor.execute(sql_check)
+            result_check = cursor.fetchone()[0]
             if result_check > 0:
                 # get warehouse name
                 sql_get_warehouse_name = sql.SQL("select current_warehouse();")
                 log.info(f"get warehouse name with sql: {sql_get_warehouse_name}")
-                self.cursor.execute(sql_get_warehouse_name)
+                cursor.execute(sql_get_warehouse_name)
                 sql_tg_replica = sql.SQL("""
                     CALL hg_table_group_set_warehouse_replica_count (
                         '{dbname}.{tg_name}',
@@ -315,29 +366,29 @@ class Hologres(VectorDB):
                     );
                     """).format(
                     tg_name=sql.SQL(self._tg_name),
-                    warehouse_name=sql.SQL(self.cursor.fetchone()[0]),
+                    warehouse_name=sql.SQL(cursor.fetchone()[0]),
                     dbname=sql.SQL(self.db_config["dbname"]),
                     replica_count=replica_count,
                 )
             log.info(f"{self.name} client set table group replica: {self._tg_name}, with sql: {sql_tg_replica}")
-            self.cursor.execute(sql_tg_replica)
+            cursor.execute(sql_tg_replica)
         except Exception as e:
             log.warning(f"Failed to set replica count, error: {e}, ignore")
         finally:
-            self.conn.commit()
+            conn.commit()
 
     def _create_table(self, dim: int):
-        assert self.conn is not None, "Connection is not initialized"
-        assert self.cursor is not None, "Cursor is not initialized"
+        conn = self._get_conn()
+        cursor = self._get_cursor()
 
         sql_tg = sql.SQL(f"CALL HG_CREATE_TABLE_GROUP ('{self._tg_name}', 1);")
         log.info(f"{self.name} client create table group : {self._tg_name}, with sql: {sql_tg}")
         try:
-            self.cursor.execute(sql_tg)
+            cursor.execute(sql_tg)
         except Exception as e:
             log.warning(f"Failed to create table group : {self._tg_name} error: {e}, ignore")
         finally:
-            self.conn.commit()
+            conn.commit()
 
         self._set_replica_count(replica_count=2)
 
@@ -354,8 +405,8 @@ class Hologres(VectorDB):
         )
         log.info(f"{self.name} client create table : {self.table_name}, with sql: {sql_table.as_string()}")
         try:
-            self.cursor.execute(sql_table)
-            self.conn.commit()
+            cursor.execute(sql_table)
+            conn.commit()
         except Exception as e:
             log.warning(f"Failed to create table : {self.table_name} error: {e}")
             raise e from None
@@ -366,8 +417,8 @@ class Hologres(VectorDB):
         metadata: list[int],
         **kwargs: Any,
     ) -> tuple[int, Exception | None]:
-        assert self.conn is not None, "Connection is not initialized"
-        assert self.cursor is not None, "Cursor is not initialized"
+        conn = self._get_conn()
+        cursor = self._get_cursor()
 
         try:
             buffer = StringIO()
@@ -375,11 +426,11 @@ class Hologres(VectorDB):
                 buffer.write("%d\t%s\n" % (metadata[i], "{" + ",".join("%f" % x for x in embeddings[i]) + "}"))
             buffer.seek(0)
 
-            with self.cursor.copy(
+            with cursor.copy(
                 sql.SQL("COPY {table_name} FROM STDIN").format(table_name=sql.Identifier(self.table_name))
             ) as copy:
                 copy.write(buffer.getvalue())
-            self.conn.commit()
+            conn.commit()
 
             return len(metadata), None
         except Exception as e:
@@ -393,17 +444,16 @@ class Hologres(VectorDB):
         filters: dict | None = None,
         timeout: int | None = None,
     ) -> list[int]:
-        assert self.conn is not None, "Connection is not initialized"
-        assert self.cursor is not None, "Cursor is not initialized"
+        cursor = self._get_cursor()
 
         ge = filters.get("id") if filters else None
         q = HoloFloat4Array(query)
 
         if ge is not None:
             params = (ge, q, k)
-            result = self.cursor.execute(self._search_query_with_filter, params, prepare=True, binary=True)
+            result = cursor.execute(self._search_query_with_filter, params, prepare=True, binary=True)
         else:
             params = (q, k)
-            result = self.cursor.execute(self._search_query_no_filter, params, prepare=True, binary=True)
+            result = cursor.execute(self._search_query_no_filter, params, prepare=True, binary=True)
 
         return [int(i[0]) for i in result.fetchall()]


### PR DESCRIPTION
This addresses the functional failure in the Hologres client introduced by 7e251b6, which added the concurrent insert runner without setting thread_safe=False for Hologres. This implements per-thread connection management via threading.local() to enable safe parallel loading.