### PR TITLE
feat: add HyperspaceDB client adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ All the database client supported
 | lindorm                  | `pip install vectordb-bench[lindorm]`       |
 | volc_mysql               | `pip install vectordb-bench[volc_mysql]`    |
 | adbpg                    | `pip install vectordb-bench[adbpg]`         |
+| hyperspacedb             | `pip install vectordb-bench[hyperspacedb]`  |
 
 ### Run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ seekdb          = [ "mysql-connector-python" ]
 volc_mysql      = [ "mysql-connector-python" ]
 pinot           = [ "requests" ]
 adbpg           = [ "psycopg", "psycopg-binary", "pgvector" ]
+hyperspacedb    = [ "hyperspacedb" ]
 
 [project.urls]
 Repository  = "https://github.com/zilliztech/VectorDBBench"

--- a/tests/test_hyperspacedb.py
+++ b/tests/test_hyperspacedb.py
@@ -1,0 +1,47 @@
+import logging
+from vectordb_bench.models import DB
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+db_config_dict = {
+    "host": "localhost:50051",
+    "api_key": "I_LOVE_HYPERSPACEDB"
+}
+
+class TestHyperspaceDB:
+    def test_insert_and_search(self):
+        assert DB.HyperspaceDB.value == "HyperspaceDB"
+
+        dbcls = DB.HyperspaceDB.init_cls
+
+        dim = 16
+        db = dbcls(
+            dim=dim,
+            db_config=db_config_dict,
+            db_case_config=None,
+            collection_name="example_collection",
+            drop_old=True,
+        )
+
+        count = 1000
+        embeddings = [[np.random.random() for _ in range(dim)] for _ in range(count)]
+
+        # insert
+        with db.init():
+            assert db.client is not None, "Hyperspace client is not connected"
+            res = db.insert_embeddings(embeddings=embeddings, metadata=range(count))
+            assert res[0] == count, f"Expected {count} inserted, got {res[0]}"
+
+        # optimize
+        with db.init():
+            db.optimize()
+
+        # search
+        with db.init():
+            test_id = np.random.randint(count)
+            q = embeddings[test_id]
+
+            res = db.search_embedding(query=q, k=10)
+            assert len(res) > 0, "No results returned"
+            assert int(res[0]) == int(test_id), f"Expected nearest neighbor to be {test_id}, got {res[0]}"

--- a/vectordb_bench/backend/clients/__init__.py
+++ b/vectordb_bench/backend/clients/__init__.py
@@ -65,10 +65,15 @@ class DB(Enum):
     SeekDB = "SeekDB"
     VolcMySQL = "VolcMySQL"
     Adbpg = "AnalyticDB for PostgreSQL"
+    HyperspaceDB = "HyperspaceDB"
 
     @property
     def init_cls(self) -> type[VectorDB]:  # noqa: PLR0911, PLR0912, C901, PLR0915
         """Import while in use"""
+        if self == DB.HyperspaceDB:
+            from .hyperspacedb.hyperspacedb import HyperspaceDB
+            return HyperspaceDB
+
         if self == DB.Milvus:
             from .milvus.milvus import Milvus
 
@@ -287,6 +292,10 @@ class DB(Enum):
     @property
     def config_cls(self) -> type[DBConfig]:  # noqa: PLR0911, PLR0912, C901, PLR0915
         """Import while in use"""
+        if self == DB.HyperspaceDB:
+            from .hyperspacedb.config import HyperspaceDBConfig
+            return HyperspaceDBConfig
+
         if self == DB.Milvus:
             from .milvus.config import MilvusConfig
 
@@ -506,6 +515,10 @@ class DB(Enum):
         self,
         index_type: IndexType | None = None,
     ) -> type[DBCaseConfig]:
+        if self == DB.HyperspaceDB:
+            from .hyperspacedb.config import HyperspaceDBIndexConfig
+            return HyperspaceDBIndexConfig
+
         if self == DB.Milvus:
             from .milvus.config import _milvus_case_config
 

--- a/vectordb_bench/backend/clients/hyperspacedb/__init__.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/__init__.py
@@ -1,0 +1,4 @@
+from .config import HyperspaceDBConfig, HyperspaceDBIndexConfig
+from .hyperspacedb import HyperspaceDB
+
+__all__ = ["HyperspaceDBConfig", "HyperspaceDBIndexConfig", "HyperspaceDB"]

--- a/vectordb_bench/backend/clients/hyperspacedb/cli.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/cli.py
@@ -1,0 +1,57 @@
+from typing import Annotated, Unpack
+
+import click
+from pydantic import SecretStr
+
+from vectordb_bench.backend.clients import DB
+from vectordb_bench.cli.cli import (
+    CommonTypedDict,
+    cli,
+    click_parameter_decorators_from_typed_dict,
+    run,
+)
+
+DBTYPE = DB.HyperspaceDB
+
+
+class HyperspaceDBTypeDict(CommonTypedDict):
+    host: Annotated[
+        str,
+        click.option("--host", type=str, help="HyperspaceDB host", default="localhost:50051"),
+    ]
+    api_key: Annotated[
+        str | None,
+        click.option("--api-key", type=str, help="HyperspaceDB API Key", required=False),
+    ]
+    m: Annotated[
+        int,
+        click.option("--m", type=int, help="HNSW Maximum Neighbors", default=16),
+    ]
+    ef_construction: Annotated[
+        int,
+        click.option("--ef-construction", type=int, help="HNSW efConstruction", default=100),
+    ]
+    ef_search: Annotated[
+        int,
+        click.option("--ef-search", type=int, help="HNSW efSearch", default=100),
+    ]
+
+
+@cli.command()
+@click_parameter_decorators_from_typed_dict(HyperspaceDBTypeDict)
+def HyperspaceDB(**parameters: Unpack[HyperspaceDBTypeDict]):
+    from .config import HyperspaceDBConfig, HyperspaceDBIndexConfig
+
+    run(
+        db=DBTYPE,
+        db_config=HyperspaceDBConfig(
+            host=parameters["host"],
+            api_key=SecretStr(parameters["api_key"]) if parameters["api_key"] else None,
+        ),
+        db_case_config=HyperspaceDBIndexConfig(
+            m=parameters["m"],
+            ef_construction=parameters["ef_construction"],
+            ef_search=parameters["ef_search"],
+        ),
+        **parameters,
+    )

--- a/vectordb_bench/backend/clients/hyperspacedb/config.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/config.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel, SecretStr
+from typing import ClassVar
+from ..api import DBCaseConfig, DBConfig, IndexType, MetricType
+
+class HyperspaceDBConfig(DBConfig):
+    _extra_empty_skip: ClassVar[frozenset[str]] = frozenset({"api_key"})
+    
+    host: str = "localhost:50051"
+    api_key: SecretStr | None = None
+    
+    def to_dict(self) -> dict:
+        return {
+            "host": self.host,
+            "api_key": self.api_key.get_secret_value() if self.api_key else None
+        }
+
+class HyperspaceDBIndexConfig(BaseModel, DBCaseConfig):
+    index: IndexType = IndexType.HNSW
+    metric_type: MetricType = MetricType.COSINE
+    m: int = 16
+    ef_construction: int = 100
+    ef_search: int = 100
+    
+    def parse_metric(self) -> str:
+        if self.metric_type == MetricType.L2:
+            return "l2"
+        if self.metric_type == MetricType.COSINE:
+            return "cosine"
+        raise ValueError("Unsupported metric type: %s" % self.metric_type)
+        
+    def index_param(self) -> dict:
+        return {
+            "m": self.m,
+            "ef_construction": self.ef_construction,
+        }
+        
+    def search_param(self) -> dict:
+        return {
+            "ef_search": self.ef_search,
+        }

--- a/vectordb_bench/backend/clients/hyperspacedb/config.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/config.py
@@ -18,7 +18,7 @@ class HyperspaceDBIndexConfig(BaseModel, DBCaseConfig):
     index: IndexType = IndexType.HNSW
     metric_type: MetricType = MetricType.COSINE
     m: int = 16
-    ef_construction: int = 100
+    ef_construction: int = 200
     ef_search: int = 100
     
     def parse_metric(self) -> str:

--- a/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
@@ -71,11 +71,31 @@ class HyperspaceDB(VectorDB):
         # Apply search param config
         try:
             self.client.configure(
+                collection=self.collection_name,
                 ef_search=self.case_config.ef_search,
-                collection=self.collection_name
+                ef_construction=self.case_config.ef_construction,
             )
         except Exception as e:
             log.warning(f"Optimize configure error: {e}")
+            
+        # Wait for background indexing to complete using gRPC stats
+        start_time = time.time()
+        timeout = 3600  # 1 hour max
+        while True:
+            if time.time() - start_time > timeout:
+                log.warning("Indexing timeout reached during optimize")
+                break
+            try:
+                stats = self.client.get_collection_stats(self.collection_name)
+                queue = stats.get("indexing_queue", 0)
+                count = stats.get("count", 0)
+                if queue == 0 and count > 0:
+                    break
+            except Exception as e:
+                log.warning(f"Error getting collection stats: {e}")
+                time.sleep(5)
+                break
+            time.sleep(1.0)
             
     def insert_embeddings(
         self,

--- a/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
@@ -1,0 +1,128 @@
+import logging
+import time
+from contextlib import contextmanager
+
+from hyperspace import HyperspaceClient
+
+from ..api import VectorDB
+from .config import HyperspaceDBIndexConfig
+
+log = logging.getLogger(__name__)
+
+class HyperspaceDB(VectorDB):
+    def __init__(
+        self,
+        dim: int,
+        db_config: dict,
+        db_case_config: HyperspaceDBIndexConfig,
+        collection_name: str = "VectorDBBenchCollection",
+        drop_old: bool = False,
+        **kwargs,
+    ):
+        self.db_config = db_config
+        self.case_config = db_case_config
+        self.collection_name = collection_name
+        
+        # Initialize client
+        host = db_config.get("host", "localhost:50051")
+        api_key = db_config.get("api_key")
+        
+        client = HyperspaceClient(host, api_key=api_key)
+        
+        if drop_old:
+            try:
+                client.delete_collection(self.collection_name)
+                time.sleep(0.5)
+            except Exception as e:
+                log.info(f"Failed to drop old collection: {e}")
+                
+        # Create collection
+        try:
+            metric = self.case_config.parse_metric()
+            client.create_collection(
+                self.collection_name,
+                dimension=dim,
+                metric=metric
+            )
+            # Pre-configure index build parameters
+            client.configure(
+                ef_search=self.case_config.ef_search,
+                ef_construction=self.case_config.ef_construction,
+                collection=self.collection_name
+            )
+        except Exception as e:
+            log.warning(f"Failed to create collection: {e}")
+            
+        client.close()
+        
+    @contextmanager
+    def init(self):
+        host = self.db_config.get("host", "localhost:50051")
+        api_key = self.db_config.get("api_key")
+        self.client = HyperspaceClient(host, api_key=api_key)
+        yield
+        self.client.close()
+        self.client = None
+        
+    def ready_to_search(self) -> bool:
+        pass
+        
+    def optimize(self, data_size: int | None = None):
+        # Apply search param config
+        try:
+            self.client.configure(
+                ef_search=self.case_config.ef_search,
+                collection=self.collection_name
+            )
+        except Exception as e:
+            log.warning(f"Optimize configure error: {e}")
+            
+    def insert_embeddings(
+        self,
+        embeddings: list[list[float]],
+        metadata: list[int],
+        **kwargs,
+    ) -> tuple[int, Exception]:
+        assert self.client is not None, "Please call self.init() before"
+        
+        # Prepare metadata
+        metas = [{"id": str(idx)} for idx in metadata]
+        
+        try:
+            self.client.batch_insert(
+                vectors=embeddings,
+                ids=metadata,
+                metadatas=metas,
+                collection=self.collection_name
+            )
+            return len(embeddings), None
+        except Exception as e:
+            log.warning(f"Failed to insert embeddings: {e}")
+            return 0, e
+            
+    def search_embedding(
+        self,
+        query: list[float],
+        k: int = 100,
+        filters: dict | None = None,
+        timeout: int | None = None
+    ) -> list[int]:
+        assert self.client is not None, "Please call self.init() before"
+        
+        # Build filter if present
+        flt = None
+        if filters:
+            # Map simple filter if supported
+            pass
+            
+        try:
+            results = self.client.search(
+                vector=query,
+                top_k=k,
+                filter=flt,
+                collection=self.collection_name
+            )
+            return [r["id"] for r in results]
+        except Exception as e:
+            log.warning(f"Failed to search: {e}")
+            return []

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -14,6 +14,7 @@ from ..backend.clients.elastic_cloud.cli import (
 )
 from ..backend.clients.endee.cli import Endee
 from ..backend.clients.hologres.cli import HologresHGraph
+from ..backend.clients.hyperspacedb.cli import HyperspaceDB
 from ..backend.clients.lancedb.cli import (
     LanceDB,
     LanceDBAutoIndex,
@@ -57,6 +58,7 @@ from .batch_cli import BatchCli
 from .cli import cli
 
 cli.add_command(AdbpgNova)
+cli.add_command(HyperspaceDB)
 cli.add_command(PgVectorHNSW)
 cli.add_command(PgVectoRSHNSW)
 cli.add_command(PgVectoRSIVFFlat)

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -3247,6 +3247,19 @@ AdbpgPerformanceConfig = [
     CaseConfigParamInput_NovaAdaptiveGamma_Adbpg,
 ]
 
+HyperspaceDBLoadConfig = [
+    CaseConfigParamInput_IndexType,
+    CaseConfigParamInput_m,
+    CaseConfigParamInput_EFConstruction_Adbpg,
+]
+
+HyperspaceDBPerformanceConfig = [
+    CaseConfigParamInput_IndexType,
+    CaseConfigParamInput_m,
+    CaseConfigParamInput_EFConstruction_Adbpg,
+    CaseConfigParamInput_EFSearch_PgVectoRS,
+]
+
 # Map DB to config
 CASE_CONFIG_MAP = {
     DB.Milvus: {
@@ -3351,6 +3364,11 @@ CASE_CONFIG_MAP = {
     DB.Adbpg: {
         CaseLabel.Load: AdbpgLoadConfig,
         CaseLabel.Performance: AdbpgPerformanceConfig,
+    },
+    DB.HyperspaceDB: {
+        CaseLabel.Load: HyperspaceDBLoadConfig,
+        CaseLabel.Performance: HyperspaceDBPerformanceConfig,
+        CaseLabel.Streaming: HyperspaceDBPerformanceConfig,
     },
 }
 

--- a/vectordb_bench/frontend/config/styles.py
+++ b/vectordb_bench/frontend/config/styles.py
@@ -40,6 +40,7 @@ HEADER_ICON = "https://assets.zilliz.com/VDB_Bench_text_icon_6c5f52a458.png"
 # Elasticsearch icon: https://assets.zilliz.com/elasticsearch_beffeadc29.png
 # Chroma icon: https://assets.zilliz.com/chroma_ceb3f06ed7.png
 DB_TO_ICON = {
+    DB.HyperspaceDB: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgZmlsbD0iYmxhY2siIC8+CiAgPHRleHQgeD0iNTAiIHk9IjcwIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjYwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjMDBmZmZmIiBmb250LXdlaWdodD0iYm9sZCI+W0hdPC90ZXh0Pgo8L3N2Zz4K",
     DB.Milvus: "https://assets.zilliz.com/milvus_c30b0d1994.png",
     DB.ZillizCloud: "https://assets.zilliz.com/zilliz_5f4cc9b050.png",
     DB.ElasticCloud: "https://assets.zilliz.com/Elatic_Cloud_dad8d6a3a3.png",


### PR DESCRIPTION
## Proposal: Add HyperspaceDB (`[H]`) as a new client in VectorDBBench

### Summary

We'd like to contribute a new backend client for **HyperspaceDB**, a vector database written in Rust (project: YAR.INK), and — if the maintainers are open to it — have it evaluated on the standard leaderboard alongside the existing clients (Milvus, Qdrant, Weaviate, PgVector, etc.).

To keep the comparison fair and easy to review, **this proposal is scoped to standard, well-understood ground**: HNSW-based ANN search under the same **L2 / Cosine** metrics are already used for every other client in the leaderboard.

### What we are explicitly *not* proposing (yet)

HyperspaceDB also implements non-Euclidean capabilities — a Lorentz/Poincaré hyperbolic index and an experimental wave-diffusion search mode. We are intentionally leaving all of that out of this PR. Reasons:

- Those modes don't map onto existing `MetricType`/case definitions in  VectorDBBench, and we don't want to ask maintainers to build new infrastructure just to evaluate us.
- We want the first data point to be a clean, apples-to-apples comparison on the exact terms the benchmark already tests everyone on.
- Hyperbolic/wave benchmarking can be a separate follow-up proposal once (if) the maintainers are interested, with their own metric/case definitions discussed on their own merits.

So, this PR tests HyperspaceDB purely as an HNSW vector index over L2/Cosine, competing on the same field as everyone else.

### What's included in the PR

- `vectordb_bench/backend/clients/hyperspacedb/`
  - `config.py` — `HyperspaceDBConfig(DBConfig)`, `HyperspaceDBIndexConfig(DBCaseConfig)` (HNSW params: `m`, `ef_construction`, `ef_search`; metric restricted to `L2`/`COSINE` for this PR)
  - `hyperspacedb.py` — `HyperspaceDB(VectorDB)` implementing the standard insert/search/optimize interface
- Registration of `HyperspaceDB` in the `DB` enum and `db_config`/`db_case_config`
- CLI command in `vectordb_bench/cli/vectordbbench.py`
- `pyproject.toml`: new `hyperspacedb` extra
- Tests under `tests/test_hyperspacedb.py` following the existing client test pattern
- Docs: a short usage section (connection params, install instructions, example `vectordbbench hyperspacedb --help` command), matching the style used for other clients

### What we're asking from maintainers

1. **Code review** of the client implementation against your `VectorDB` interface conventions.
2. If the client is accepted, we understand the results on the public leaderboard require running on your standard reference client hardware (8 vCPU / 32GB, same region as the server) for consistency with the other entries. We're happy to provide a hosted or Docker-deployable instance of HyperspaceDB for that run, or to run it ourselves against your published methodology and submit results for your verification - whichever is easier on your side.
3. We are not asking for special-casing or a separate "non-Euclidean" leaderboard track in this PR — just a seat at the existing L2/Cosine table.

### Why we think this is worth your time

We believe HyperspaceDB's HNSW implementation performs competitively against the databases currently on the leaderboard, even under the standard metrics they were designed around — that's the specific claim this PR is meant to let your benchmark verify (or refute) independently, rather than something we're asserting without your test.

### Checklist

- [ ] Client implements full `VectorDB` interface (insert, search, optimize, `ready_to_load`, `need_normalize_cosine`)
- [ ] `db_config` / `db_case_config` reviewed against project conventions
- [ ] CLI command added and documented
- [ ] `pyproject.toml` extra added (`hyperspacedb`)
- [ ] Tests included and passing
- [ ] Docs updated
- [ ] Open to running on maintainers' reference hardware for leaderboard inclusion