### PR TITLE
Add hyperspacedb client

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ All the database client supported
 | lindorm                  | `pip install vectordb-bench[lindorm]`       |
 | volc_mysql               | `pip install vectordb-bench[volc_mysql]`    |
 | adbpg                    | `pip install vectordb-bench[adbpg]`         |
+| hyperspacedb             | `pip install vectordb-bench[hyperspacedb]`  |
 
 ### Run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ seekdb          = [ "mysql-connector-python" ]
 volc_mysql      = [ "mysql-connector-python" ]
 pinot           = [ "requests" ]
 adbpg           = [ "psycopg", "psycopg-binary", "pgvector" ]
+hyperspacedb    = [ "hyperspacedb" ]
 
 [project.urls]
 Repository  = "https://github.com/zilliztech/VectorDBBench"

--- a/tests/test_hyperspacedb.py
+++ b/tests/test_hyperspacedb.py
@@ -1,0 +1,47 @@
+import logging
+from vectordb_bench.models import DB
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+db_config_dict = {
+    "host": "localhost:50051",
+    "api_key": "I_LOVE_HYPERSPACEDB"
+}
+
+class TestHyperspaceDB:
+    def test_insert_and_search(self):
+        assert DB.HyperspaceDB.value == "HyperspaceDB"
+
+        dbcls = DB.HyperspaceDB.init_cls
+
+        dim = 16
+        db = dbcls(
+            dim=dim,
+            db_config=db_config_dict,
+            db_case_config=None,
+            collection_name="example_collection",
+            drop_old=True,
+        )
+
+        count = 1000
+        embeddings = [[np.random.random() for _ in range(dim)] for _ in range(count)]
+
+        # insert
+        with db.init():
+            assert db.client is not None, "Hyperspace client is not connected"
+            res = db.insert_embeddings(embeddings=embeddings, metadata=range(count))
+            assert res[0] == count, f"Expected {count} inserted, got {res[0]}"
+
+        # optimize
+        with db.init():
+            db.optimize()
+
+        # search
+        with db.init():
+            test_id = np.random.randint(count)
+            q = embeddings[test_id]
+
+            res = db.search_embedding(query=q, k=10)
+            assert len(res) > 0, "No results returned"
+            assert int(res[0]) == int(test_id), f"Expected nearest neighbor to be {test_id}, got {res[0]}"

--- a/vectordb_bench/backend/clients/__init__.py
+++ b/vectordb_bench/backend/clients/__init__.py
@@ -65,10 +65,15 @@ class DB(Enum):
     SeekDB = "SeekDB"
     VolcMySQL = "VolcMySQL"
     Adbpg = "AnalyticDB for PostgreSQL"
+    HyperspaceDB = "HyperspaceDB"
 
     @property
     def init_cls(self) -> type[VectorDB]:  # noqa: PLR0911, PLR0912, C901, PLR0915
         """Import while in use"""
+        if self == DB.HyperspaceDB:
+            from .hyperspacedb.hyperspacedb import HyperspaceDB
+            return HyperspaceDB
+
         if self == DB.Milvus:
             from .milvus.milvus import Milvus
 
@@ -287,6 +292,10 @@ class DB(Enum):
     @property
     def config_cls(self) -> type[DBConfig]:  # noqa: PLR0911, PLR0912, C901, PLR0915
         """Import while in use"""
+        if self == DB.HyperspaceDB:
+            from .hyperspacedb.config import HyperspaceDBConfig
+            return HyperspaceDBConfig
+
         if self == DB.Milvus:
             from .milvus.config import MilvusConfig
 
@@ -506,6 +515,10 @@ class DB(Enum):
         self,
         index_type: IndexType | None = None,
     ) -> type[DBCaseConfig]:
+        if self == DB.HyperspaceDB:
+            from .hyperspacedb.config import HyperspaceDBIndexConfig
+            return HyperspaceDBIndexConfig
+
         if self == DB.Milvus:
             from .milvus.config import _milvus_case_config
 

--- a/vectordb_bench/backend/clients/hyperspacedb/__init__.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/__init__.py
@@ -1,0 +1,4 @@
+from .config import HyperspaceDBConfig, HyperspaceDBIndexConfig
+from .hyperspacedb import HyperspaceDB
+
+__all__ = ["HyperspaceDBConfig", "HyperspaceDBIndexConfig", "HyperspaceDB"]

--- a/vectordb_bench/backend/clients/hyperspacedb/cli.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/cli.py
@@ -1,0 +1,57 @@
+from typing import Annotated, Unpack
+
+import click
+from pydantic import SecretStr
+
+from vectordb_bench.backend.clients import DB
+from vectordb_bench.cli.cli import (
+    CommonTypedDict,
+    cli,
+    click_parameter_decorators_from_typed_dict,
+    run,
+)
+
+DBTYPE = DB.HyperspaceDB
+
+
+class HyperspaceDBTypeDict(CommonTypedDict):
+    host: Annotated[
+        str,
+        click.option("--host", type=str, help="HyperspaceDB host", default="localhost:50051"),
+    ]
+    api_key: Annotated[
+        str | None,
+        click.option("--api-key", type=str, help="HyperspaceDB API Key", required=False),
+    ]
+    m: Annotated[
+        int,
+        click.option("--m", type=int, help="HNSW Maximum Neighbors", default=16),
+    ]
+    ef_construction: Annotated[
+        int,
+        click.option("--ef-construction", type=int, help="HNSW efConstruction", default=100),
+    ]
+    ef_search: Annotated[
+        int,
+        click.option("--ef-search", type=int, help="HNSW efSearch", default=100),
+    ]
+
+
+@cli.command()
+@click_parameter_decorators_from_typed_dict(HyperspaceDBTypeDict)
+def HyperspaceDB(**parameters: Unpack[HyperspaceDBTypeDict]):
+    from .config import HyperspaceDBConfig, HyperspaceDBIndexConfig
+
+    run(
+        db=DBTYPE,
+        db_config=HyperspaceDBConfig(
+            host=parameters["host"],
+            api_key=SecretStr(parameters["api_key"]) if parameters["api_key"] else None,
+        ),
+        db_case_config=HyperspaceDBIndexConfig(
+            m=parameters["m"],
+            ef_construction=parameters["ef_construction"],
+            ef_search=parameters["ef_search"],
+        ),
+        **parameters,
+    )

--- a/vectordb_bench/backend/clients/hyperspacedb/config.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/config.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel, SecretStr
+from typing import ClassVar
+from ..api import DBCaseConfig, DBConfig, IndexType, MetricType
+
+class HyperspaceDBConfig(DBConfig):
+    _extra_empty_skip: ClassVar[frozenset[str]] = frozenset({"api_key"})
+    
+    host: str = "localhost:50051"
+    api_key: SecretStr | None = None
+    
+    def to_dict(self) -> dict:
+        return {
+            "host": self.host,
+            "api_key": self.api_key.get_secret_value() if self.api_key else None
+        }
+
+class HyperspaceDBIndexConfig(BaseModel, DBCaseConfig):
+    index: IndexType = IndexType.HNSW
+    metric_type: MetricType = MetricType.COSINE
+    m: int = 16
+    ef_construction: int = 100
+    ef_search: int = 100
+    
+    def parse_metric(self) -> str:
+        if self.metric_type == MetricType.L2:
+            return "l2"
+        if self.metric_type == MetricType.COSINE:
+            return "cosine"
+        raise ValueError("Unsupported metric type: %s" % self.metric_type)
+        
+    def index_param(self) -> dict:
+        return {
+            "m": self.m,
+            "ef_construction": self.ef_construction,
+        }
+        
+    def search_param(self) -> dict:
+        return {
+            "ef_search": self.ef_search,
+        }

--- a/vectordb_bench/backend/clients/hyperspacedb/config.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/config.py
@@ -18,7 +18,7 @@ class HyperspaceDBIndexConfig(BaseModel, DBCaseConfig):
     index: IndexType = IndexType.HNSW
     metric_type: MetricType = MetricType.COSINE
     m: int = 16
-    ef_construction: int = 100
+    ef_construction: int = 200
     ef_search: int = 100
     
     def parse_metric(self) -> str:

--- a/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
@@ -133,7 +133,20 @@ class HyperspaceDB(VectorDB):
     ) -> list[int]:
         assert self.client is not None, "Please call self.init() before"
         
-        # Build filter if present
+        # Direct gRPC fast-path to bypass Python SDK overhead when no filters are present
+        if not filters:
+            try:
+                from hyperspace.proto import hyperspace_pb2
+                req = hyperspace_pb2.SearchRequest(
+                    vector=query,
+                    top_k=k,
+                    collection=self.collection_name
+                )
+                resp = self.client.stub.Search(req, metadata=self.client.metadata)
+                return [r.id for r in resp.results]
+            except Exception as e:
+                log.warning(f"Fast-path search failed: {e}. Falling back to SDK search.")
+        
         flt = None
         if filters:
             # Map simple filter if supported

--- a/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
@@ -71,11 +71,31 @@ class HyperspaceDB(VectorDB):
         # Apply search param config
         try:
             self.client.configure(
+                collection=self.collection_name,
                 ef_search=self.case_config.ef_search,
-                collection=self.collection_name
+                ef_construction=self.case_config.ef_construction,
             )
         except Exception as e:
             log.warning(f"Optimize configure error: {e}")
+            
+        # Wait for background indexing to complete using gRPC stats
+        start_time = time.time()
+        timeout = 3600  # 1 hour max
+        while True:
+            if time.time() - start_time > timeout:
+                log.warning("Indexing timeout reached during optimize")
+                break
+            try:
+                stats = self.client.get_collection_stats(self.collection_name)
+                queue = stats.get("indexing_queue", 0)
+                count = stats.get("count", 0)
+                if queue == 0 and count > 0:
+                    break
+            except Exception as e:
+                log.warning(f"Error getting collection stats: {e}")
+                time.sleep(5)
+                break
+            time.sleep(1.0)
             
     def insert_embeddings(
         self,

--- a/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
@@ -1,0 +1,128 @@
+import logging
+import time
+from contextlib import contextmanager
+
+from hyperspace import HyperspaceClient
+
+from ..api import VectorDB
+from .config import HyperspaceDBIndexConfig
+
+log = logging.getLogger(__name__)
+
+class HyperspaceDB(VectorDB):
+    def __init__(
+        self,
+        dim: int,
+        db_config: dict,
+        db_case_config: HyperspaceDBIndexConfig,
+        collection_name: str = "VectorDBBenchCollection",
+        drop_old: bool = False,
+        **kwargs,
+    ):
+        self.db_config = db_config
+        self.case_config = db_case_config
+        self.collection_name = collection_name
+        
+        # Initialize client
+        host = db_config.get("host", "localhost:50051")
+        api_key = db_config.get("api_key")
+        
+        client = HyperspaceClient(host, api_key=api_key)
+        
+        if drop_old:
+            try:
+                client.delete_collection(self.collection_name)
+                time.sleep(0.5)
+            except Exception as e:
+                log.info(f"Failed to drop old collection: {e}")
+                
+        # Create collection
+        try:
+            metric = self.case_config.parse_metric()
+            client.create_collection(
+                self.collection_name,
+                dimension=dim,
+                metric=metric
+            )
+            # Pre-configure index build parameters
+            client.configure(
+                ef_search=self.case_config.ef_search,
+                ef_construction=self.case_config.ef_construction,
+                collection=self.collection_name
+            )
+        except Exception as e:
+            log.warning(f"Failed to create collection: {e}")
+            
+        client.close()
+        
+    @contextmanager
+    def init(self):
+        host = self.db_config.get("host", "localhost:50051")
+        api_key = self.db_config.get("api_key")
+        self.client = HyperspaceClient(host, api_key=api_key)
+        yield
+        self.client.close()
+        self.client = None
+        
+    def ready_to_search(self) -> bool:
+        pass
+        
+    def optimize(self, data_size: int | None = None):
+        # Apply search param config
+        try:
+            self.client.configure(
+                ef_search=self.case_config.ef_search,
+                collection=self.collection_name
+            )
+        except Exception as e:
+            log.warning(f"Optimize configure error: {e}")
+            
+    def insert_embeddings(
+        self,
+        embeddings: list[list[float]],
+        metadata: list[int],
+        **kwargs,
+    ) -> tuple[int, Exception]:
+        assert self.client is not None, "Please call self.init() before"
+        
+        # Prepare metadata
+        metas = [{"id": str(idx)} for idx in metadata]
+        
+        try:
+            self.client.batch_insert(
+                vectors=embeddings,
+                ids=metadata,
+                metadatas=metas,
+                collection=self.collection_name
+            )
+            return len(embeddings), None
+        except Exception as e:
+            log.warning(f"Failed to insert embeddings: {e}")
+            return 0, e
+            
+    def search_embedding(
+        self,
+        query: list[float],
+        k: int = 100,
+        filters: dict | None = None,
+        timeout: int | None = None
+    ) -> list[int]:
+        assert self.client is not None, "Please call self.init() before"
+        
+        # Build filter if present
+        flt = None
+        if filters:
+            # Map simple filter if supported
+            pass
+            
+        try:
+            results = self.client.search(
+                vector=query,
+                top_k=k,
+                filter=flt,
+                collection=self.collection_name
+            )
+            return [r["id"] for r in results]
+        except Exception as e:
+            log.warning(f"Failed to search: {e}")
+            return []

--- a/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
@@ -7,9 +7,17 @@ from hyperspace import HyperspaceClient
 from ..api import VectorDB
 from .config import HyperspaceDBIndexConfig
 
+from vectordb_bench.backend.filter import Filter, FilterOp
+
 log = logging.getLogger(__name__)
 
 class HyperspaceDB(VectorDB):
+    supported_filter_types = [
+        FilterOp.NonFilter,
+        FilterOp.NumGE,
+        FilterOp.StrEqual,
+    ]
+
     def __init__(
         self,
         dim: int,
@@ -22,6 +30,7 @@ class HyperspaceDB(VectorDB):
         self.db_config = db_config
         self.case_config = db_case_config
         self.collection_name = collection_name
+        self.expr = None
         
         # Initialize client
         host = db_config.get("host", "localhost:50051")
@@ -48,6 +57,7 @@ class HyperspaceDB(VectorDB):
             client.configure(
                 ef_search=self.case_config.ef_search,
                 ef_construction=self.case_config.ef_construction,
+                m=self.case_config.m,
                 collection=self.collection_name
             )
         except Exception as e:
@@ -70,6 +80,16 @@ class HyperspaceDB(VectorDB):
     def need_normalize_cosine(self) -> bool:
         """Whether this database needs to normalize dataset to support COSINE"""
         return True
+
+    def prepare_filter(self, filters: Filter):
+        if filters.type == FilterOp.NonFilter:
+            self.expr = None
+        elif filters.type == FilterOp.NumGE:
+            self.expr = [{"type": "range", "key": filters.int_field, "gte": filters.int_value}]
+        elif filters.type == FilterOp.StrEqual:
+            self.expr = [{"type": "match", "key": filters.label_field, "value": filters.label_value}]
+        else:
+            raise ValueError(f"Unsupported filter type for HyperspaceDB: {filters.type}")
         
     def optimize(self, data_size: int | None = None):
         # Apply search param config
@@ -78,6 +98,7 @@ class HyperspaceDB(VectorDB):
                 collection=self.collection_name,
                 ef_search=self.case_config.ef_search,
                 ef_construction=self.case_config.ef_construction,
+                m=self.case_config.m,
             )
         except Exception as e:
             log.warning(f"Optimize configure error: {e}")
@@ -110,7 +131,11 @@ class HyperspaceDB(VectorDB):
         assert self.client is not None, "Please call self.init() before"
         
         # Prepare metadata
-        metas = [{"id": str(idx)} for idx in metadata]
+        labels_data = kwargs.get("labels_data")
+        if labels_data is not None:
+            metas = [{"id": str(idx), "labels": str(label)} for idx, label in zip(metadata, labels_data)]
+        else:
+            metas = [{"id": str(idx)} for idx in metadata]
         
         try:
             self.client.batch_insert(
@@ -133,8 +158,13 @@ class HyperspaceDB(VectorDB):
     ) -> list[int]:
         assert self.client is not None, "Please call self.init() before"
         
+        # Use pre-prepared filter expression if available, fallback to dynamic filters
+        expr = self.expr
+        if not expr and filters:
+            expr = [{"type": "match", "key": k, "value": str(v)} for k, v in filters.items()]
+        
         # Direct gRPC fast-path to bypass Python SDK overhead when no filters are present
-        if not filters:
+        if not expr:
             try:
                 from hyperspace.proto import hyperspace_pb2
                 req = hyperspace_pb2.SearchRequest(
@@ -147,16 +177,11 @@ class HyperspaceDB(VectorDB):
             except Exception as e:
                 log.warning(f"Fast-path search failed: {e}. Falling back to SDK search.")
         
-        flt = None
-        if filters:
-            # Map simple filter if supported
-            pass
-            
         try:
             results = self.client.search(
                 vector=query,
                 top_k=k,
-                filter=flt,
+                filters=expr,
                 collection=self.collection_name
             )
             return [r["id"] for r in results]

--- a/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
+++ b/vectordb_bench/backend/clients/hyperspacedb/hyperspacedb.py
@@ -27,7 +27,7 @@ class HyperspaceDB(VectorDB):
         host = db_config.get("host", "localhost:50051")
         api_key = db_config.get("api_key")
         
-        client = HyperspaceClient(host, api_key=api_key)
+        client = HyperspaceClient(host, api_key=api_key, pool_size=64)
         
         if drop_old:
             try:
@@ -59,13 +59,17 @@ class HyperspaceDB(VectorDB):
     def init(self):
         host = self.db_config.get("host", "localhost:50051")
         api_key = self.db_config.get("api_key")
-        self.client = HyperspaceClient(host, api_key=api_key)
+        self.client = HyperspaceClient(host, api_key=api_key, pool_size=64)
         yield
         self.client.close()
         self.client = None
         
     def ready_to_search(self) -> bool:
         pass
+
+    def need_normalize_cosine(self) -> bool:
+        """Whether this database needs to normalize dataset to support COSINE"""
+        return True
         
     def optimize(self, data_size: int | None = None):
         # Apply search param config

--- a/vectordb_bench/cli/vectordbbench.py
+++ b/vectordb_bench/cli/vectordbbench.py
@@ -14,6 +14,7 @@ from ..backend.clients.elastic_cloud.cli import (
 )
 from ..backend.clients.endee.cli import Endee
 from ..backend.clients.hologres.cli import HologresHGraph
+from ..backend.clients.hyperspacedb.cli import HyperspaceDB
 from ..backend.clients.lancedb.cli import (
     LanceDB,
     LanceDBAutoIndex,
@@ -57,6 +58,7 @@ from .batch_cli import BatchCli
 from .cli import cli
 
 cli.add_command(AdbpgNova)
+cli.add_command(HyperspaceDB)
 cli.add_command(PgVectorHNSW)
 cli.add_command(PgVectoRSHNSW)
 cli.add_command(PgVectoRSIVFFlat)

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -3247,6 +3247,19 @@ AdbpgPerformanceConfig = [
     CaseConfigParamInput_NovaAdaptiveGamma_Adbpg,
 ]
 
+HyperspaceDBLoadConfig = [
+    CaseConfigParamInput_IndexType,
+    CaseConfigParamInput_m,
+    CaseConfigParamInput_EFConstruction_Adbpg,
+]
+
+HyperspaceDBPerformanceConfig = [
+    CaseConfigParamInput_IndexType,
+    CaseConfigParamInput_m,
+    CaseConfigParamInput_EFConstruction_Adbpg,
+    CaseConfigParamInput_EFSearch_PgVectoRS,
+]
+
 # Map DB to config
 CASE_CONFIG_MAP = {
     DB.Milvus: {
@@ -3351,6 +3364,11 @@ CASE_CONFIG_MAP = {
     DB.Adbpg: {
         CaseLabel.Load: AdbpgLoadConfig,
         CaseLabel.Performance: AdbpgPerformanceConfig,
+    },
+    DB.HyperspaceDB: {
+        CaseLabel.Load: HyperspaceDBLoadConfig,
+        CaseLabel.Performance: HyperspaceDBPerformanceConfig,
+        CaseLabel.Streaming: HyperspaceDBPerformanceConfig,
     },
 }
 

--- a/vectordb_bench/frontend/config/styles.py
+++ b/vectordb_bench/frontend/config/styles.py
@@ -40,6 +40,7 @@ HEADER_ICON = "https://assets.zilliz.com/VDB_Bench_text_icon_6c5f52a458.png"
 # Elasticsearch icon: https://assets.zilliz.com/elasticsearch_beffeadc29.png
 # Chroma icon: https://assets.zilliz.com/chroma_ceb3f06ed7.png
 DB_TO_ICON = {
+    DB.HyperspaceDB: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgZmlsbD0iYmxhY2siIC8+CiAgPHRleHQgeD0iNTAiIHk9IjcwIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiBmb250LXNpemU9IjYwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjMDBmZmZmIiBmb250LXdlaWdodD0iYm9sZCI+W0hdPC90ZXh0Pgo8L3N2Zz4K",
     DB.Milvus: "https://assets.zilliz.com/milvus_c30b0d1994.png",
     DB.ZillizCloud: "https://assets.zilliz.com/zilliz_5f4cc9b050.png",
     DB.ElasticCloud: "https://assets.zilliz.com/Elatic_Cloud_dad8d6a3a3.png",

--- a/vectordb_bench/results/HyperspaceDB/result_20260712_2026071212_hyperspacedb.json
+++ b/vectordb_bench/results/HyperspaceDB/result_20260712_2026071212_hyperspacedb.json
@@ -1,0 +1,99 @@
+{
+  "run_id": "62622ba63f1c47c793e1471770fb2a10",
+  "task_label": "2026071212",
+  "results": [
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 53.0701,
+        "optimize_duration": 982.4558,
+        "load_duration": 1035.5259,
+        "qps": 119.5232,
+        "serial_latency_p99": 0.0118,
+        "serial_latency_p95": 0.0109,
+        "recall": 0.9462,
+        "ndcg": 0.9599,
+        "conc_num_list": [
+          1
+        ],
+        "conc_qps_list": [
+          119.5232
+        ],
+        "conc_latency_p99_list": [
+          0.011835757478838794
+        ],
+        "conc_latency_p95_list": [
+          0.010872666441719048
+        ],
+        "conc_latency_avg_list": [
+          0.008361369310156625
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 1000000,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {
+          "num_per_batch": 100,
+          "load_concurrency": 0
+        },
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 5,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    }
+  ],
+  "file_fmt": "result_{}_{}_{}.json",
+  "timestamp": 1783807200.0
+}

--- a/vectordb_bench/results/HyperspaceDB/result_20260712_2026071213_hyperspacedb.json
+++ b/vectordb_bench/results/HyperspaceDB/result_20260712_2026071213_hyperspacedb.json
@@ -1,0 +1,99 @@
+{
+  "run_id": "12997717849449e68c26c274c77a1d1a",
+  "task_label": "2026071213",
+  "results": [
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 46.0489,
+        "optimize_duration": 593.6236,
+        "load_duration": 639.6725,
+        "qps": 203.6497,
+        "serial_latency_p99": 0.0062,
+        "serial_latency_p95": 0.0058,
+        "recall": 0.9374,
+        "ndcg": 0.9511,
+        "conc_num_list": [
+          1
+        ],
+        "conc_qps_list": [
+          203.6497
+        ],
+        "conc_latency_p99_list": [
+          0.006120336796157062
+        ],
+        "conc_latency_p95_list": [
+          0.005847845610696822
+        ],
+        "conc_latency_avg_list": [
+          0.00490593512023579
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 1000000,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {
+          "num_per_batch": 100,
+          "load_concurrency": 0
+        },
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 5,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    }
+  ],
+  "file_fmt": "result_{}_{}_{}.json",
+  "timestamp": 1783807200.0
+}

--- a/vectordb_bench/results/HyperspaceDB/result_20260712_2026071214_hyperspacedb.json
+++ b/vectordb_bench/results/HyperspaceDB/result_20260712_2026071214_hyperspacedb.json
@@ -1,0 +1,794 @@
+{
+  "run_id": "d175f436a74c4a3c9a1615574672b2c4",
+  "task_label": "2026071214",
+  "results": [
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 41.8016,
+        "optimize_duration": 720.6131,
+        "load_duration": 762.4147,
+        "qps": 1067.8766,
+        "serial_latency_p99": 0.0101,
+        "serial_latency_p95": 0.0097,
+        "recall": 0.9452,
+        "ndcg": 0.9586,
+        "conc_num_list": [
+          1,
+          5,
+          10,
+          20,
+          30,
+          40,
+          60,
+          80
+        ],
+        "conc_qps_list": [
+          128.2479,
+          621.2241,
+          1001.8124,
+          1067.8766,
+          1055.3801,
+          1039.0434,
+          1019.8385,
+          1015.7757
+        ],
+        "conc_latency_p99_list": [
+          0.010083990453276782,
+          0.010413146250648424,
+          0.016113541030790657,
+          0.06342757661768712,
+          0.09159422895754687,
+          0.11477615523152057,
+          0.1589652874844614,
+          0.19226219120319024
+        ],
+        "conc_latency_p95_list": [
+          0.009637802172801456,
+          0.009921776482951828,
+          0.013657417031936347,
+          0.03250307273992803,
+          0.05343252047896385,
+          0.07786878581100606,
+          0.111910516466014,
+          0.1371945830178447
+        ],
+        "conc_latency_avg_list": [
+          0.007789061415357479,
+          0.008038166083478748,
+          0.009966457144400255,
+          0.018674496434089083,
+          0.028335049544428288,
+          0.03831250435274196,
+          0.05830997227731253,
+          0.07793574372611273
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 500000,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {
+          "num_per_batch": 100,
+          "load_concurrency": 0
+        },
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 10,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1,
+              5,
+              10,
+              20,
+              30,
+              40,
+              60,
+              80
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    },
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 0.0,
+        "optimize_duration": 0.0,
+        "load_duration": 762.4147,
+        "qps": 87.368,
+        "serial_latency_p99": 0.1219,
+        "serial_latency_p95": 0.1198,
+        "recall": 0.9449,
+        "ndcg": 0.9584,
+        "conc_num_list": [
+          1,
+          5,
+          10,
+          20,
+          30,
+          40,
+          60,
+          80
+        ],
+        "conc_qps_list": [
+          8.7914,
+          43.2222,
+          81.1681,
+          87.0161,
+          87.3314,
+          87.368,
+          86.1306,
+          85.2896
+        ],
+        "conc_latency_p99_list": [
+          0.12435946107842029,
+          0.12440010914579035,
+          0.1428588032152038,
+          0.31568611065857105,
+          0.4633241035678657,
+          0.6008124551479703,
+          0.8806899169867393,
+          1.1366911421122492
+        ],
+        "conc_latency_p95_list": [
+          0.12070596071425825,
+          0.1187632750137709,
+          0.1344199998769909,
+          0.28599373381584875,
+          0.42453221703181043,
+          0.558030325139407,
+          0.81015306248446,
+          1.0586211875197478
+        ],
+        "conc_latency_avg_list": [
+          0.1136377588127013,
+          0.11538861729382449,
+          0.12286727616391124,
+          0.22901325840353193,
+          0.3418299061913379,
+          0.4549602876735834,
+          0.6896549737448098,
+          0.9240290041603552
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 0,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {},
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 12,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1,
+              5,
+              10,
+              20,
+              30,
+              40,
+              60,
+              80
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    },
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 0.0,
+        "optimize_duration": 0.0,
+        "load_duration": 762.4147,
+        "qps": 137.6545,
+        "serial_latency_p99": 0.0881,
+        "serial_latency_p95": 0.0755,
+        "recall": 0.9547,
+        "ndcg": 0.967,
+        "conc_num_list": [
+          1,
+          5,
+          10,
+          20,
+          30,
+          40,
+          60,
+          80
+        ],
+        "conc_qps_list": [
+          15.1313,
+          70.5259,
+          130.1996,
+          137.6545,
+          135.879,
+          134.8699,
+          135.3946,
+          134.1785
+        ],
+        "conc_latency_p99_list": [
+          0.0865796018228866,
+          0.1323904192954069,
+          0.09603670298005454,
+          0.24185886844177767,
+          0.39336458531674,
+          0.48749090612051066,
+          0.6436965464020614,
+          0.8053537916531787
+        ],
+        "conc_latency_p95_list": [
+          0.076739620603621,
+          0.07222609551390632,
+          0.08730916701606474,
+          0.2090703397785546,
+          0.3288700754521414,
+          0.4239731668902094,
+          0.5792697667784523,
+          0.7395427252165974
+        ],
+        "conc_latency_avg_list": [
+          0.06601984734022683,
+          0.07082097559372723,
+          0.07663433261946846,
+          0.14481145231143,
+          0.21972085558227972,
+          0.2947143576328986,
+          0.439789550802413,
+          0.5889849021948839
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 0,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {},
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 14,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1,
+              5,
+              10,
+              20,
+              30,
+              40,
+              60,
+              80
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    },
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 56.6607,
+        "optimize_duration": 590.751,
+        "load_duration": 647.4117,
+        "qps": 1697.9916,
+        "serial_latency_p99": 0.0062,
+        "serial_latency_p95": 0.006,
+        "recall": 0.9375,
+        "ndcg": 0.9513,
+        "conc_num_list": [
+          1,
+          5,
+          10,
+          20,
+          30,
+          40,
+          60,
+          80
+        ],
+        "conc_qps_list": [
+          201.1391,
+          954.8265,
+          1555.4045,
+          1697.9916,
+          1674.0102,
+          1628.7735,
+          1620.5734,
+          1606.4271
+        ],
+        "conc_latency_p99_list": [
+          0.006264741737395525,
+          0.006534985173493623,
+          0.010726521257311106,
+          0.039689521398395225,
+          0.047442107308888565,
+          0.07775463489757373,
+          0.10869675248046407,
+          0.12693975201342253
+        ],
+        "conc_latency_p95_list": [
+          0.005941362166777253,
+          0.006238416209816933,
+          0.00855817696719896,
+          0.019839197761029936,
+          0.0337189998012036,
+          0.05039672060520388,
+          0.07125668367079921,
+          0.08725001639686525
+        ],
+        "conc_latency_avg_list": [
+          0.004966687106125332,
+          0.005230420421598983,
+          0.006419391963548976,
+          0.011739309518328777,
+          0.017836923123242556,
+          0.024454370213994076,
+          0.0367946258922899,
+          0.0493751170097713
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 1000000,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {
+          "num_per_batch": 100,
+          "load_concurrency": 0
+        },
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 5,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1,
+              5,
+              10,
+              20,
+              30,
+              40,
+              60,
+              80
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    },
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 0.0,
+        "optimize_duration": 0.0,
+        "load_duration": 647.4117,
+        "qps": 42.6453,
+        "serial_latency_p99": 0.2472,
+        "serial_latency_p95": 0.2439,
+        "recall": 0.9371,
+        "ndcg": 0.951,
+        "conc_num_list": [
+          1,
+          5,
+          10,
+          20,
+          30,
+          40,
+          60,
+          80
+        ],
+        "conc_qps_list": [
+          4.3189,
+          21.0129,
+          39.5408,
+          42.3425,
+          42.6453,
+          42.2641,
+          41.7798,
+          41.5672
+        ],
+        "conc_latency_p99_list": [
+          0.2474690593208652,
+          0.2658580467908177,
+          0.29754339002771296,
+          0.5694501112378203,
+          0.8323646020406158,
+          1.1200287380896041,
+          1.7879712272487813,
+          2.2624025689018894
+        ],
+        "conc_latency_p95_list": [
+          0.2434065106412163,
+          0.252996079379227,
+          0.2713546002283692,
+          0.542225570496521,
+          0.7949954897339921,
+          1.07067802050733,
+          1.605885081287124,
+          2.170565842158976
+        ],
+        "conc_latency_avg_list": [
+          0.2313373229940995,
+          0.23771138911008996,
+          0.2516548139497921,
+          0.46981396171448586,
+          0.6984242073069007,
+          0.9378588565349406,
+          1.413915318086419,
+          1.8803775400243112
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 0,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {},
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 7,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1,
+              5,
+              10,
+              20,
+              30,
+              40,
+              60,
+              80
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    },
+    {
+      "metrics": {
+        "max_load_count": 0,
+        "insert_duration": 0.0,
+        "optimize_duration": 0.0,
+        "load_duration": 647.4117,
+        "qps": 59.1148,
+        "serial_latency_p99": 0.2487,
+        "serial_latency_p95": 0.2051,
+        "recall": 0.953,
+        "ndcg": 0.9658,
+        "conc_num_list": [
+          1,
+          5,
+          10,
+          20,
+          30,
+          40,
+          60,
+          80
+        ],
+        "conc_qps_list": [
+          6.1432,
+          30.534,
+          55.1238,
+          58.5733,
+          59.1148,
+          58.4167,
+          58.5262,
+          58.2362
+        ],
+        "conc_latency_p99_list": [
+          0.2185167950368485,
+          0.16940182997728698,
+          0.22048857311485331,
+          0.46404855548054913,
+          0.6568337464763317,
+          0.8519639647612349,
+          1.31608037731261,
+          1.6207599717006087
+        ],
+        "conc_latency_p95_list": [
+          0.18294472519773983,
+          0.167442935728468,
+          0.20541455819038673,
+          0.417507679326809,
+          0.6031129375041928,
+          0.8034419589035678,
+          1.1802631963859311,
+          1.5406029088189825
+        ],
+        "conc_latency_avg_list": [
+          0.1626463760974238,
+          0.16358786664527344,
+          0.18064264668020288,
+          0.3399116292382479,
+          0.5045830063322116,
+          0.6790753035739896,
+          1.0133975636398294,
+          1.3498548400924317
+        ],
+        "payload_profile": "ids_only",
+        "payload_estimated_bytes_per_query": 2000,
+        "inserted_count": 0,
+        "insert_rows_per_second": 0.0,
+        "insert_completion_seconds": 0.0,
+        "searchable_after_insert_seconds": 0.0,
+        "indexed_after_searchable_seconds": 0.0,
+        "additional_parameters": {},
+        "st_ideal_insert_duration": 0,
+        "st_search_stage_list": [],
+        "st_search_time_list": [],
+        "st_max_qps_list_list": [],
+        "st_recall_list": [],
+        "st_ndcg_list": [],
+        "st_serial_latency_p99_list": [],
+        "st_serial_latency_p95_list": [],
+        "st_conc_failed_rate_list": [],
+        "st_conc_num_list_list": [],
+        "st_conc_qps_list_list": [],
+        "st_conc_latency_p99_list_list": [],
+        "st_conc_latency_p95_list_list": [],
+        "st_conc_latency_avg_list_list": []
+      },
+      "task_config": {
+        "db": "HyperspaceDB",
+        "db_config": {
+          "db_label": "",
+          "version": "",
+          "note": "",
+          "host": "localhost:50051",
+          "api_key": "**********"
+        },
+        "db_case_config": {
+          "index": "HNSW",
+          "metric_type": "COSINE",
+          "m": 16,
+          "ef_construction": 256,
+          "ef_search": 100
+        },
+        "case_config": {
+          "case_id": 9,
+          "custom_case": null,
+          "k": 100,
+          "concurrency_search_config": {
+            "num_concurrency": [
+              1,
+              5,
+              10,
+              20,
+              30,
+              40,
+              60,
+              80
+            ],
+            "concurrency_duration": 30,
+            "concurrency_timeout": 3600,
+            "serial_cooldown": 0.0
+          }
+        },
+        "stages": [
+          "drop_old",
+          "load",
+          "search_serial",
+          "search_concurrent"
+        ],
+        "load_concurrency": 0
+      },
+      "label": ":)"
+    }
+  ],
+  "file_fmt": "result_{}_{}_{}.json",
+  "timestamp": 1783807200.0
+}


### PR DESCRIPTION
## Proposal: Add HyperspaceDB (`[H]`) as a new client in VectorDBBench

### Summary

We'd like to contribute a new backend client for **HyperspaceDB**, a vector database written in Rust (project: YAR.INK), and — if the maintainers are open to it — have it evaluated on the standard leaderboard alongside the existing clients (Milvus, Qdrant, Weaviate, PgVector, etc.).

To keep the comparison fair and easy to review, **this proposal is scoped to standard, well-understood ground**: HNSW-based ANN search under the same **L2 / Cosine** metrics are already used for every other client in the leaderboard.

### What we are explicitly *not* proposing (yet)

HyperspaceDB also implements non-Euclidean capabilities — a Lorentz/Poincaré hyperbolic index and an experimental wave-diffusion search mode. We are intentionally leaving all of that out of this PR. Reasons:

- Those modes don't map onto existing `MetricType`/case definitions in  VectorDBBench, and we don't want to ask maintainers to build new infrastructure just to evaluate us.
- We want the first data point to be a clean, apples-to-apples comparison on the exact terms the benchmark already tests everyone on.
- Hyperbolic/wave benchmarking can be a separate follow-up proposal once (if) the maintainers are interested, with their own metric/case definitions discussed on their own merits.

So, this PR tests HyperspaceDB purely as an HNSW vector index over L2/Cosine, competing on the same field as everyone else.

### What's included in the PR

- `vectordb_bench/backend/clients/hyperspacedb/`
  - `config.py` — `HyperspaceDBConfig(DBConfig)`, `HyperspaceDBIndexConfig(DBCaseConfig)` (HNSW params: `m`, `ef_construction`, `ef_search`; metric restricted to `L2`/`COSINE` for this PR)
  - `hyperspacedb.py` — `HyperspaceDB(VectorDB)` implementing the standard insert/search/optimize interface
- Registration of `HyperspaceDB` in the `DB` enum and `db_config`/`db_case_config`
- CLI command in `vectordb_bench/cli/vectordbbench.py`
- `pyproject.toml`: new `hyperspacedb` extra
- Tests under `tests/test_hyperspacedb.py` following the existing client test pattern
- Docs: a short usage section (connection params, install instructions, example `vectordbbench hyperspacedb --help` command), matching the style used for other clients

### What we're asking from maintainers

1. **Code review** of the client implementation against your `VectorDB` interface conventions.
2. If the client is accepted, we understand the results on the public leaderboard require running on your standard reference client hardware (8 vCPU / 32GB, same region as the server) for consistency with the other entries. We're happy to provide a hosted or Docker-deployable instance of HyperspaceDB for that run, or to run it ourselves against your published methodology and submit results for your verification - whichever is easier on your side.
3. We are not asking for special-casing or a separate "non-Euclidean" leaderboard track in this PR — just a seat at the existing L2/Cosine table.

### Why we think this is worth your time

We believe HyperspaceDB's HNSW implementation performs competitively against the databases currently on the leaderboard, even under the standard metrics they were designed around — that's the specific claim this PR is meant to let your benchmark verify (or refute) independently, rather than something we're asserting without your test.

### Checklist

- [ ] Client implements full `VectorDB` interface (insert, search, optimize, `ready_to_load`, `need_normalize_cosine`)
- [ ] `db_config` / `db_case_config` reviewed against project conventions
- [ ] CLI command added and documented
- [ ] `pyproject.toml` extra added (`hyperspacedb`)
- [ ] Tests included and passing
- [ ] Docs updated
- [ ] Open to running on maintainers' reference hardware for leaderboard inclusion
