### PR TITLE
feat(cli): add common note support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Commands:
 ```
 To list the options for each command, execute `vectordbbench [command] --help`
 
+Use `--note` or `--note-file` to preserve deployment, resource, client, network, and constraint context in each result JSON under `task_config.db_config.note`. The options are mutually exclusive. Prefer `--note-file` for structured or multiline context, and never include credentials, tokens, or sensitive connection details.
+
+```shell
+vectordbbench zillizautoindex \
+  --note-file ./run-context.json \
+  <other options>
+```
+
 ```text
 $ vectordbbench pgvectorhnsw --help
 Usage: vectordbbench pgvectorhnsw [OPTIONS]
@@ -118,6 +126,9 @@ Options:
                                   Case type
   --db-label TEXT                 Db label, default: date in ISO format
                                   [default: 2024-05-20T20:26:31.113290]
+  --note TEXT                     Run context stored with each result
+                                  [default: ""]
+  --note-file FILE                Read run context from a UTF-8 text file
   --dry-run                       Print just the configuration and exit
                                   without running the tasks
   --k INTEGER                     K value for number of nearest neighbors to

--- a/tests/test_cli_note.py
+++ b/tests/test_cli_note.py
@@ -1,8 +1,10 @@
+import time
 from pathlib import Path
 
 from click.testing import CliRunner
 from pytest import MonkeyPatch
 
+from vectordb_bench.backend.clients.endee import cli as endee_cli
 from vectordb_bench.backend.clients.test import cli as test_cli
 from vectordb_bench.cli import cli as common_cli
 
@@ -17,6 +19,23 @@ def invoke_test_command(monkeypatch: MonkeyPatch, args: list[str]):
     monkeypatch.setattr(common_cli.benchmark_runner, "run", fake_run)
     monkeypatch.setattr(common_cli.benchmark_runner, "has_running", lambda: False)
     result = CliRunner().invoke(test_cli.Test, args)
+    return result, captured
+
+
+def invoke_endee_command(monkeypatch: MonkeyPatch, args: list[str]):
+    captured = {}
+
+    def fake_run(tasks, task_label):
+        captured["task"] = tasks[0]
+        captured["task_label"] = task_label
+
+    monkeypatch.setattr(endee_cli.benchmark_runner, "run", fake_run)
+    monkeypatch.setattr(endee_cli.benchmark_runner, "has_running", lambda: False)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    result = CliRunner().invoke(
+        endee_cli.Endee,
+        ["--token", "secret", "--index-name", "test-index", *args],
+    )
     return result, captured
 
 
@@ -43,6 +62,17 @@ def test_common_cli_reads_note_file_into_task_config(monkeypatch: MonkeyPatch, t
     note_file.write_text(note + "\n", encoding="utf-8")
 
     result, captured = invoke_test_command(monkeypatch, ["--note-file", str(note_file)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["task"].db_config.note == note
+
+
+def test_endee_cli_reads_note_file_into_task_config(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    note = '{"schema":"vdbbench-context/v1","deployment":"endee-local"}'
+    note_file = tmp_path / "endee-run-context.json"
+    note_file.write_text(note, encoding="utf-8")
+
+    result, captured = invoke_endee_command(monkeypatch, ["--note-file", str(note_file)])
 
     assert result.exit_code == 0, result.output
     assert captured["task"].db_config.note == note

--- a/tests/test_cli_note.py
+++ b/tests/test_cli_note.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+from pytest import MonkeyPatch
+
+from vectordb_bench.backend.clients.test import cli as test_cli
+from vectordb_bench.cli import cli as common_cli
+
+
+def invoke_test_command(monkeypatch: MonkeyPatch, args: list[str]):
+    captured = {}
+
+    def fake_run(tasks, task_label):
+        captured["task"] = tasks[0]
+        captured["task_label"] = task_label
+
+    monkeypatch.setattr(common_cli.benchmark_runner, "run", fake_run)
+    monkeypatch.setattr(common_cli.benchmark_runner, "has_running", lambda: False)
+    result = CliRunner().invoke(test_cli.Test, args)
+    return result, captured
+
+
+def test_common_cli_exposes_note_options() -> None:
+    result = CliRunner().invoke(test_cli.Test, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--note TEXT" in result.output
+    assert "--note-file FILE" in result.output
+
+
+def test_common_cli_stores_inline_note_in_task_config(monkeypatch: MonkeyPatch) -> None:
+    note = '{"schema":"vdbbench-context/v1","deployment":"local"}'
+
+    result, captured = invoke_test_command(monkeypatch, ["--note", note])
+
+    assert result.exit_code == 0, result.output
+    assert captured["task"].db_config.note == note
+
+
+def test_common_cli_reads_note_file_into_task_config(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    note = '{\n  "schema": "vdbbench-context/v1",\n  "deployment": "managed"\n}'
+    note_file = tmp_path / "run-context.json"
+    note_file.write_text(note + "\n", encoding="utf-8")
+
+    result, captured = invoke_test_command(monkeypatch, ["--note-file", str(note_file)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["task"].db_config.note == note
+
+
+def test_common_cli_rejects_inline_note_with_note_file(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    note_file = tmp_path / "run-context.json"
+    note_file.write_text("context", encoding="utf-8")
+
+    result, _ = invoke_test_command(
+        monkeypatch,
+        ["--note", "inline", "--note-file", str(note_file)],
+    )
+
+    assert result.exit_code != 0
+    assert "--note and --note-file cannot be used together" in result.output
+
+
+def test_common_cli_rejects_empty_note_file(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    note_file = tmp_path / "empty.txt"
+    note_file.write_text("", encoding="utf-8")
+
+    result, _ = invoke_test_command(monkeypatch, ["--note-file", str(note_file)])
+
+    assert result.exit_code != 0
+    assert "Note file is empty" in result.output
+
+
+def test_common_cli_rejects_non_utf8_note_file(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    note_file = tmp_path / "invalid.txt"
+    with note_file.open("wb") as output:
+        output.write(b"\xff")
+
+    result, _ = invoke_test_command(monkeypatch, ["--note-file", str(note_file)])
+
+    assert result.exit_code != 0
+    assert "Note file is not valid UTF-8" in result.output

--- a/tests/test_cli_note.py
+++ b/tests/test_cli_note.py
@@ -91,6 +91,19 @@ def test_common_cli_rejects_inline_note_with_note_file(monkeypatch: MonkeyPatch,
     assert "--note and --note-file cannot be used together" in result.output
 
 
+def test_common_cli_rejects_empty_inline_note_with_note_file(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    note_file = tmp_path / "run-context.json"
+    note_file.write_text("context", encoding="utf-8")
+
+    result, _ = invoke_test_command(monkeypatch, ["--note", "", "--note-file", str(note_file)])
+
+    assert result.exit_code != 0
+    assert "--note and --note-file cannot be used together" in result.output
+
+
 def test_common_cli_rejects_empty_note_file(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     note_file = tmp_path / "empty.txt"
     note_file.write_text("", encoding="utf-8")

--- a/vectordb_bench/backend/clients/endee/cli.py
+++ b/vectordb_bench/backend/clients/endee/cli.py
@@ -10,6 +10,7 @@ from vectordb_bench.cli.cli import (
     click_parameter_decorators_from_typed_dict,
     get_custom_case_config,
     parse_task_stages,
+    resolve_db_note,
 )
 from vectordb_bench.models import (
     CaseConfig,
@@ -94,6 +95,7 @@ def Endee(**parameters):
 
     # Filter out None values before creating config
     params_for_nd = {k: v for k, v in parameters.items() if v is not None}
+    params_for_nd["note"] = resolve_db_note(parameters["note"], parameters["note_file"])
     db_config = EndeeConfig(**params_for_nd)
 
     custom_case_config = get_custom_case_config(parameters)

--- a/vectordb_bench/backend/clients/pinecone/cli.py
+++ b/vectordb_bench/backend/clients/pinecone/cli.py
@@ -26,10 +26,6 @@ class PineconeTypedDict(TypedDict):
         str,
         click.option("--version", type=str, help="Database version", default="", show_default=True),
     ]
-    note: Annotated[
-        str,
-        click.option("--note", type=str, help="Additional notes", default="", show_default=True),
-    ]
 
 
 class PineconeIndexTypedDict(CommonTypedDict, PineconeTypedDict): ...
@@ -45,7 +41,6 @@ def Pinecone(**parameters: Unpack[PineconeIndexTypedDict]):
         db_config=PineconeConfig(
             db_label=parameters["db_label"],
             version=parameters["version"],
-            note=parameters["note"],
             api_key=SecretStr(parameters["api_key"]),
             index_name=parameters["index_name"],
         ),

--- a/vectordb_bench/cli/cli.py
+++ b/vectordb_bench/cli/cli.py
@@ -66,6 +66,20 @@ def click_get_defaults_from_file(ctx, param, value):  # noqa: ANN001, ARG001
     return value
 
 
+def resolve_db_note(note: str, note_file: Path | None) -> str:
+    if note and note_file is not None:
+        raise click.UsageError("--note and --note-file cannot be used together")
+    if note_file is None:
+        return note
+    try:
+        content = note_file.read_text(encoding="utf-8").rstrip("\r\n")
+    except UnicodeDecodeError as e:
+        raise click.BadParameter("Note file is not valid UTF-8", param_hint="--note-file") from e
+    if not content.strip():
+        raise click.BadParameter("Note file is empty", param_hint="--note-file")
+    return content
+
+
 def click_parameter_decorators_from_typed_dict(
     typed_dict: type,
 ) -> Callable[[click.decorators.FC], click.decorators.FC]:
@@ -358,6 +372,25 @@ class CommonTypedDict(TypedDict):
             help="Db label, default: date in ISO format",
             show_default=True,
             default=datetime.now().isoformat(),
+        ),
+    ]
+    note: Annotated[
+        str,
+        click.option(
+            "--note",
+            type=str,
+            help="Run context stored with each result",
+            default="",
+            show_default=True,
+        ),
+    ]
+    note_file: Annotated[
+        Path | None,
+        click.option(
+            "--note-file",
+            type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+            help="Read run context from a UTF-8 text file",
+            default=None,
         ),
     ]
     dry_run: Annotated[
@@ -828,6 +861,10 @@ def run(
         db_case_config (DBCaseConfig)
         **parameters: expects keys from CommonTypedDict
     """
+
+    db_config = db_config.model_copy(
+        update={"note": resolve_db_note(parameters["note"], parameters["note_file"])},
+    )
 
     task = TaskConfig(
         db=db,

--- a/vectordb_bench/cli/cli.py
+++ b/vectordb_bench/cli/cli.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import click
+from click.core import ParameterSource
 from yaml import load
 
 from .. import config
@@ -67,7 +68,13 @@ def click_get_defaults_from_file(ctx, param, value):  # noqa: ANN001, ARG001
 
 
 def resolve_db_note(note: str, note_file: Path | None) -> str:
-    if note and note_file is not None:
+    ctx = click.get_current_context()
+    note_source = ctx.get_parameter_source("note")
+    note_file_source = ctx.get_parameter_source("note_file")
+    note_supplied = note_source not in {None, ParameterSource.DEFAULT}
+    note_file_supplied = note_file_source not in {None, ParameterSource.DEFAULT}
+
+    if note_supplied and note_file_supplied:
         raise click.UsageError("--note and --note-file cannot be used together")
     if note_file is None:
         return note


### PR DESCRIPTION
## What this changes

- Adds shared `--note` and `--note-file` options to backend CLI commands.
- Resolves the supplied context centrally into `task_config.db_config.note`, which is already serialized into each result JSON.
- Ensures Endee's custom CLI runner also resolves note files before constructing its task.
- Rejects conflicting options, empty note files, and non-UTF-8 note files.
- Preserves Pinecone's existing `--note` behavior through the common implementation.
- Documents how to attach structured or multiline benchmark context.

## Compatibility

- Existing CLI commands remain unchanged when neither option is supplied.
- This does not change the result schema because `DBConfig.note` already exists.
- Backend connection behavior is unchanged: provider clients receive their existing explicit `DBConfig.to_dict()` connection fields, not the note metadata.

## Verification

- `make lint`
- `make unittest` — 1 passed
- `python -m pytest tests/test_cli_note.py -q` — 7 passed
- `python -m pytest tests/test_milvus_zilliz_cli.py -q` — 2 passed
- Verified `--note` and `--note-file` help output for Zilliz Cloud and Pinecone commands.
