### PR TITLE
Fix Milvus HNSW-PQ `m` parameter conflicts with `M`.

### DIFF
--- a/vectordb_bench/backend/clients/milvus/cli.py
+++ b/vectordb_bench/backend/clients/milvus/cli.py
@@ -179,6 +179,14 @@ class MilvusRefineTypedDict(TypedDict):
 
 
 class MilvusHNSWPQTypedDict(CommonTypedDict, MilvusTypedDict, MilvusHNSWTypedDict, MilvusRefineTypedDict):
+    pq_m: Annotated[
+        int,
+        click.option(
+            "--pq-m",
+            type=int,
+            required=True,
+        ),
+    ]
     nbits: Annotated[
         int,
         click.option(
@@ -209,6 +217,7 @@ def MilvusHNSWPQ(**parameters: Unpack[MilvusHNSWPQTypedDict]):
                 M=parameters["m"],
                 efConstruction=parameters["ef_construction"],
                 ef=parameters["ef_search"],
+                m=parameters["pq_m"],
                 nbits=parameters["nbits"],
                 refine=parameters["refine"],
                 refine_type=parameters["refine_type"],


### PR DESCRIPTION
The `m` parameter in Milvus HNSW-PQ is not adjustable when using the command-line. Even worse, setting `M` and `m` leads to a situation where the order in which you define the parameters in your YAML-file determines what value ends up in `M`.

## Proposed solution
Add a separate command-line switch `--pq-m` to specify the `m` for product quantization.

However, while this fixes the frontend, which is sufficient for my current needs, I strongly suggest you consider the renaming the parameter in the backend as well. This idea to have parameters that only differ in upper/lower-case (i.e., `M` vs. `m`) is an accident bound to happen.

## To replicate the problem

```
git checkout main

echo "milvushnswpq:
  dry_run: True
  drop_old: False
  load: False
  load_concurrency: 48
  search_serial: True
  search_concurrent: True
  case_type: Performance768D1M
  db_label: perf_768d_1m
  k: 200
  concurrency_duration: 60
  num_concurrency: 128
  concurrency_timeout: 1800
  serial_cooldown: 5
  task_label: search_perf_768d_1m
  uri: http://milvus-standalone:19530
  db_name: perf_768d_1m
  num_shards: 2
  replica_number: 2
  use_partition_key: True
  M: 8
  ef_construction: 384
  ef_search: 128
  m: 64
  refine: True
  refine_type: fp16
  refine_k: 2.0
  nbits: 16" > test.yaml

python3 -m vectordb_bench.cli.vectordbbench milvushnswpq --config-file test.yaml
```
*Output:*
```
2026-07-17 14:49:19,728 | INFO: Task:
TaskConfig(
  db=<DB.Milvus: 'Milvus'>,
  ...
  db_case_config=HNSWPQConfig(index=<IndexType.HNSW_PQ: 'HNSW_PQ'>,
    metric_type=None, 
    use_partition_key=True, M=64, efConstruction=384, ef=128,
    m=32, nbits=16, refine=True, refine_type=<SQType.FP16: 'FP16'>, refine_k=2.0
  ), ...
```
Note how `M=64` now. Because `m` is the later value. `m=32` because it is literally not hooked up in the backend.


## To replicate the fix
```
git checkout hnswpq_pram_passing  # assuming you got bashimao/VectorDBBench cloned

python3 -m vectordb_bench.cli.vectordbbench milvushnswpq --config-file test.yaml
```
*Output:*
```
Usage: python -m vectordb_bench.cli.vectordbbench milvushnswpq
           [OPTIONS]
Try 'python -m vectordb_bench.cli.vectordbbench milvushnswpq --help' for help.

Error: Missing option '--pq-m'.
```

```
git checkout hnswpq_pram_passing  # assuming you got bashimao/VectorDBBench cloned

echo "milvushnswpq:
  dry_run: True
  drop_old: False
  load: False
  load_concurrency: 48
  search_serial: True
  search_concurrent: True
  case_type: Performance768D1M
  db_label: perf_768d_1m
  k: 200
  concurrency_duration: 60
  num_concurrency: 128
  concurrency_timeout: 1800
  serial_cooldown: 5
  task_label: search_perf_768d_1m
  uri: http://milvus-standalone:19530
  db_name: perf_768d_1m
  num_shards: 2
  replica_number: 2
  use_partition_key: True
  m: 8
  ef_construction: 384
  ef_search: 128
  pq_m: 64
  refine: True
  refine_type: fp16
  refine_k: 2.0
  nbits: 16" > test.yaml
```
*Output:*
```
2026-07-17 15:11:49,018 | INFO: Task:
TaskConfig(
  db=<DB.Milvus: 'Milvus'>,
  ...
  db_case_config=HNSWPQConfig(index=<IndexType.HNSW_PQ: 'HNSW_PQ'>,
    metric_type=None, use_partition_key=True, M=8, efConstruction=384, ef=128,
    m=64, nbits=16, refine=True, refine_type=<SQType.FP16: 'FP16'>, refine_k=2.0
  ), ...
```
Note how `M=8` regardless of whether it is spelled upper- or lowercase in the YAML, and `m=64` because in the YAML `pq_m: 64`.


