### PR TITLE
Upgrade to Debian 12 "bookworm"; Debian 10 "buster" is EOL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster as builder-image
+FROM python:3.11-bookworm as builder-image
 
 RUN apt-get update
 
@@ -6,7 +6,7 @@ COPY install/requirements_py3.11.txt .
 RUN pip3 install -U pip
 RUN pip3 install --no-cache-dir -r requirements_py3.11.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 COPY --from=builder-image /usr/local/bin /usr/local/bin
 COPY --from=builder-image /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages

--- a/install/requirements_py3.11.txt
+++ b/install/requirements_py3.11.txt
@@ -1,5 +1,5 @@
-grpcio==1.53.2
-grpcio-tools==1.53.0
+grpcio==1.66.2
+grpcio-tools==1.66.2
 qdrant-client
 pinecone
 weaviate-client
@@ -18,6 +18,7 @@ streamlit>=1.23.0
 streamlit_extras
 tornado>=6.0
 tqdm
+ujson
 s3fs
 psutil
 polars


### PR DESCRIPTION
Debian 10 "Buster" is end-of-life and doesn't receive security updates anymore for quite a while.

## Proposed solution

Switch to Debian 12 "Bookworm" because Debian 11 "Bullseye" will go EOL next month.

Debian Version | Codename | Standard Security EOL | Long Term Support (LTS) EOL | Status
-- | -- | -- | -- | --
Debian 10 | Buster | September 2022 | June 2024 | Fully End-of-Life
Debian 11 | Bullseye | August 2024 | August 2026 | Near EOL (LTS active)
Debian 12 | Bookworm | July 2026 | June 2028 | Active (LTS transition)
Debian 13 | Trixie | August 2028 | June 2030 | Current Stable


## To replicate the problem

Note that the `buster` APT repos aren't even available via [Debian's main mirror](http://ftp.debian.org/debian/dists) anymore.

```
$ docker run -it --rm python:3.11-buster apt update
Unable to find image 'python:3.11-buster' locally
3.11-buster: Pulling from library/python
e8371d57f742: Pull complete
e7349847b324: Pull complete
f104dc4fba2c: Pull complete
1879ae1722a3: Pull complete
a82b33408f1c: Pull complete
cec6ede40ade: Pull complete
4e1ecbe8c78c: Pull complete
954d693af399: Pull complete
Digest: sha256:3a19b4d6ce4402d11bb19aa11416e4a262a60a57707a5cda5787a81285df2666
Status: Downloaded newer image for python:3.11-buster
Ign:1 http://deb.debian.org/debian buster InRelease
Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
Ign:3 http://deb.debian.org/debian buster-updates InRelease
Err:4 http://deb.debian.org/debian buster Release
  404  Not Found [IP: 151.101.42.132 80]
Err:5 http://deb.debian.org/debian-security buster/updates Release
  404  Not Found [IP: 151.101.42.132 80]
Err:6 http://deb.debian.org/debian buster-updates Release
  404  Not Found [IP: 151.101.42.132 80]
Reading package lists... Done
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details
```