### PR TITLE
Update database client installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,33 +41,34 @@ All the database client supported
 
 | Optional database client | install command                             |
 |--------------------------|---------------------------------------------|
+| adbpg                    | `pip install 'vectordb-bench[adbpg]'`         |
+| alisql                   | `pip install 'vectordb-bench[alisql]'`      |
+| aliyun_opensearch        | `pip install 'vectordb-bench[aliyun_opensearch]'` |
+| awsopensearch            | `pip install 'vectordb-bench[opensearch]'` |
+| chromadb                 | `pip install 'vectordb-bench[chromadb]'`      |
+| cockroachdb              | `pip install 'vectordb-bench[cockroachdb]'`   |
+| doris                    | `pip install 'vectordb-bench[doris]'`         |
+| elastic, aliyun_elasticsearch| `pip install 'vectordb-bench[elastic]'`       |
+| endee                    | `pip install 'vectordb-bench[endee]'`         |
+| hologres                 | `pip install 'vectordb-bench[hologres]'`      |
+| lancedb                  | `pip install 'vectordb-bench[lancedb]'`       |
+| lindorm                  | `pip install 'vectordb-bench[lindorm]'`       |
+| memorydb                 | `pip install 'vectordb-bench[memorydb]'`      |
+| mongodb                  | `pip install 'vectordb-bench[mongodb]'`       |
+| oceanbase                | `pip install 'vectordb-bench[oceanbase]'`     |
+| pgvecto.rs               | `pip install 'vectordb-bench[pgvecto_rs]'`    |
+| pgvector, pgvectorscale, pgdiskann, alloydb, vectorchord | `pip install 'vectordb-bench[pgvector]'`      |
+| pinecone                 | `pip install 'vectordb-bench[pinecone]'`      |
+| polardb                  | `pip install 'vectordb-bench[polardb]'`       |
 | pymilvus, zilliz_cloud (*default*)     | `pip install vectordb-bench`                |
-| qdrant                   | `pip install vectordb-bench[qdrant]`        |
-| pinecone                 | `pip install vectordb-bench[pinecone]`      |
-| weaviate                 | `pip install vectordb-bench[weaviate]`      |
-| elastic, aliyun_elasticsearch| `pip install vectordb-bench[elastic]`       |
-| pgvector, pgvectorscale, pgdiskann, alloydb, vectorchord | `pip install vectordb-bench[pgvector]`      |
-| pgvecto.rs               | `pip install vectordb-bench[pgvecto_rs]`    |
-| redis                    | `pip install vectordb-bench[redis]`         |
-| memorydb                 | `pip install vectordb-bench[memorydb]`      |
-| chromadb                 | `pip install vectordb-bench[chromadb]`      |
-| cockroachdb              | `pip install vectordb-bench[cockroachdb]`   |
-| awsopensearch            | `pip install vectordb-bench[opensearch]` |
-| aliyun_opensearch        | `pip install vectordb-bench[aliyun_opensearch]` |
-| mongodb                  | `pip install vectordb-bench[mongodb]`       |
-| tidb                     | `pip install vectordb-bench[tidb]`          |
-| vespa                    | `pip install vectordb-bench[vespa]`         |
-| oceanbase                | `pip install vectordb-bench[oceanbase]`     |
-| hologres                 | `pip install vectordb-bench[hologres]`      |
-| tencent_es               | `pip install vectordb-bench[tencent_es]`    |
-| alisql                   | `pip install vectordb-bench[alisql]`      |
-| polardb                  | `pip install vectordb-bench[polardb]`       |
-| doris                    | `pip install vectordb-bench[doris]`         |
-| zvec                     | `pip install vectordb-bench[zvec]`          |
-| endee                    | `pip install vectordb-bench[endee]`         |
-| lindorm                  | `pip install vectordb-bench[lindorm]`       |
-| volc_mysql               | `pip install vectordb-bench[volc_mysql]`    |
-| adbpg                    | `pip install vectordb-bench[adbpg]`         |
+| qdrant                   | `pip install 'vectordb-bench[qdrant]'`        |
+| redis                    | `pip install 'vectordb-bench[redis]'`         |
+| tencent_es               | `pip install 'vectordb-bench[tencent_es]'`    |
+| tidb                     | `pip install 'vectordb-bench[tidb]'`          |
+| vespa                    | `pip install 'vectordb-bench[vespa]'`         |
+| volc_mysql               | `pip install 'vectordb-bench[volc_mysql]'`    |
+| weaviate                 | `pip install 'vectordb-bench[weaviate]'`      |
+| zvec                     | `pip install 'vectordb-bench[zvec]'`          |
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ All the database client supported
 | aliyun_opensearch        | `pip install 'vectordb-bench[aliyun_opensearch]'` |
 | awsopensearch            | `pip install 'vectordb-bench[opensearch]'` |
 | chromadb                 | `pip install 'vectordb-bench[chromadb]'`      |
+| clickhouse               | `pip install 'vectordb-bench[clickhouse]'`    |
 | cockroachdb              | `pip install 'vectordb-bench[cockroachdb]'`   |
 | doris                    | `pip install 'vectordb-bench[doris]'`         |
 | elastic, aliyun_elasticsearch| `pip install 'vectordb-bench[elastic]'`       |
@@ -53,18 +54,22 @@ All the database client supported
 | hologres                 | `pip install 'vectordb-bench[hologres]'`      |
 | lancedb                  | `pip install 'vectordb-bench[lancedb]'`       |
 | lindorm                  | `pip install 'vectordb-bench[lindorm]'`       |
+| mariadb                  | `pip install 'vectordb-bench[mariadb]'`       |
 | memorydb                 | `pip install 'vectordb-bench[memorydb]'`      |
 | mongodb                  | `pip install 'vectordb-bench[mongodb]'`       |
 | oceanbase                | `pip install 'vectordb-bench[oceanbase]'`     |
 | pgvecto.rs               | `pip install 'vectordb-bench[pgvecto_rs]'`    |
 | pgvector, pgvectorscale, pgdiskann, alloydb, vectorchord | `pip install 'vectordb-bench[pgvector]'`      |
 | pinecone                 | `pip install 'vectordb-bench[pinecone]'`      |
+| pinot                    | `pip install 'vectordb-bench[pinot]'`         |
 | polardb                  | `pip install 'vectordb-bench[polardb]'`       |
-| pymilvus, zilliz_cloud (*default*)     | `pip install vectordb-bench`                |
+| pymilvus, zilliz_cloud (*default*)     | `pip install vectordb-bench`    |
 | qdrant                   | `pip install 'vectordb-bench[qdrant]'`        |
 | redis                    | `pip install 'vectordb-bench[redis]'`         |
+| seekdb                   | `pip install 'vectordb-bench[seekdb]'`        |
 | tencent_es               | `pip install 'vectordb-bench[tencent_es]'`    |
 | tidb                     | `pip install 'vectordb-bench[tidb]'`          |
+| turbopuffer              | `pip install 'vectordb-bench[turbopuffer]'`   |
 | vespa                    | `pip install 'vectordb-bench[vespa]'`         |
 | volc_mysql               | `pip install 'vectordb-bench[volc_mysql]'`    |
 | weaviate                 | `pip install 'vectordb-bench[weaviate]'`      |


### PR DESCRIPTION
A few minor changes:

- Sort commands alphabetically
- Add lancedb
- Make commands copy-pasteable. See:

```bash
~/temp/vdbb 10svdbb ❯ uv pip install vectordb-bench[pgvector]
zsh: no matches found: vectordb-bench[pgvector]

~/temp/vdbbvdbb ❯ uv pip install 'vectordb-bench[pgvector]'
Resolved 93 packages in 715ms
Prepared 3 packages in 143ms
Installed 3 packages in 2ms
 + pgvector==0.5.0
 + psycopg==3.3.4
 + psycopg-binary==3.3.4
```

Please just let me know if you maybe don't want one of these changes and I'll undo that.