### PR TITLE
fix(pgvector): fix vector extension not existing before register_vector

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster as builder-image
+FROM python:3.11 as builder-image
 
 RUN apt-get update
 

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,11 @@
 	"workspaceFolder": "/opt/code/VectorDBBench",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker": {
+			"moby": false
+		}
+	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [

--- a/install/requirements_py3.11.txt
+++ b/install/requirements_py3.11.txt
@@ -1,5 +1,5 @@
-grpcio==1.53.2
-grpcio-tools==1.53.0
+grpcio>=1.66.2
+grpcio-tools>=1.66.2
 qdrant-client
 pinecone
 weaviate-client

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -23,10 +23,12 @@ import pickle
 from unittest.mock import MagicMock
 
 import numpy as np
+import psycopg
 import pytest
 
 from vectordb_bench.backend.clients import DB
 from vectordb_bench.backend.clients.pgvector.config import PgVectorHNSWConfig
+from vectordb_bench.backend.clients.pgvector.pgvector import PgVector
 from vectordb_bench.backend.dataset import Dataset, DatasetSource
 from vectordb_bench.backend.filter import Filter, FilterOp, non_filter
 from vectordb_bench.backend.runner.concurrent_runner import ConcurrentInsertRunner
@@ -84,6 +86,13 @@ def random_embeddings(n: int = COUNT, d: int = DIM) -> list[list[float]]:
 
 class TestPgVectorBasic:
     """Unit tests for the PgVector client (no subprocess)."""
+    def test_create_connection_installs_vector_extension(self):
+        conn, cursor = PgVector._create_connection(**DB_CONFIG["connect_config"])
+        try:
+            assert conn.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'").fetchone() is not None
+        finally:
+            cursor.close()
+            conn.close()
 
     def test_insert_and_search(self):
         db = make_db("test_basic")

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -23,7 +23,6 @@ import pickle
 from unittest.mock import MagicMock
 
 import numpy as np
-import psycopg
 import pytest
 
 from vectordb_bench.backend.clients import DB

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -23,7 +23,9 @@ import pickle
 from unittest.mock import MagicMock
 
 import numpy as np
+import psycopg
 import pytest
+from psycopg import sql
 
 from vectordb_bench.backend.clients import DB
 from vectordb_bench.backend.clients.pgvector.config import PgVectorHNSWConfig
@@ -84,8 +86,16 @@ def random_embeddings(n: int = COUNT, d: int = DIM) -> list[list[float]]:
 
 
 class TestPgVectorBasic:
-    """Unit tests for the PgVector client (no subprocess)."""
+    # """Unit tests for the PgVector client (no subprocess)."""
     def test_create_connection_installs_vector_extension(self):
+        dbname = DB_CONFIG["connect_config"]["dbname"]
+        admin_config = {**DB_CONFIG["connect_config"], "dbname": "postgres"}
+        with psycopg.connect(**admin_config, autocommit=True) as admin_conn:
+            admin_conn.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(sql.Identifier(dbname))
+            )
+            admin_conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(dbname)))
+
         conn, cursor = PgVector._create_connection(**DB_CONFIG["connect_config"])
         try:
             assert conn.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'").fetchone() is not None

--- a/vectordb_bench/backend/clients/pgvector/pgvector.py
+++ b/vectordb_bench/backend/clients/pgvector/pgvector.py
@@ -57,10 +57,6 @@ class PgVector(VectorDB):
         # construct basic units
         self.conn, self.cursor = self._create_connection(**self.connect_config)
 
-        # create vector extension
-        self.cursor.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        self.conn.commit()
-
         log.info(f"{self.name} config values: {self.connect_config}\n{self.case_config}")
         if not any(
             (
@@ -90,6 +86,8 @@ class PgVector(VectorDB):
     @staticmethod
     def _create_connection(**kwargs) -> tuple[Connection, Cursor]:
         conn = psycopg.connect(**kwargs)
+        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        conn.commit()
         register_vector(conn)
         conn.autocommit = False
         cursor = conn.cursor()


### PR DESCRIPTION
This fixes:

```
Traceback (most recent call last):
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/vectordb_bench/interface.py", line 179, in _async_task_v2
    case_res.metrics = runner.run(drop_old)
                       ^^^^^^^^^^^^^^^^^^^^
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/vectordb_bench/backend/task_runner.py", line 151, in run
    self._pre_run(drop_old)
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/vectordb_bench/backend/task_runner.py", line 142, in _pre_run
    self.init_db(drop_old)
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/vectordb_bench/backend/task_runner.py", line 131, in init_db
    self.db = db_cls(
              ^^^^^^^
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/vectordb_bench/backend/clients/pgvector/pgvector.py", line 58, in __init__
    self.conn, self.cursor = self._create_connection(**self.connect_config)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/vectordb_bench/backend/clients/pgvector/pgvector.py", line 93, in _create_connection
    register_vector(conn)
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/pgvector/psycopg/register.py", line 12, in register_vector
    register_vector_info(context, info)
  File "/home/andy/temp/vdbb/.venv/lib/python3.12/site-packages/pgvector/psycopg/vector.py", line 49, in register_vector_info
    raise psycopg.ProgrammingError('vector type not found in the database')
psycopg.ProgrammingError: vector type not found in the database
```