### PR TITLE
fix query_mode supoort milvus db type

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,7 +957,7 @@ K must be positive, and LAION-100M rejects values above 1,000,000. Filtered LAIO
 
 Wide GT remains in Parquet/Arrow form and is opened inside the serial-search subprocess one query row at a time. Results include primary `recall@K`, `recall_at` for the available cutoffs among 100, 1K, 10K, 100K, and 1M, plus serial and concurrent p50/p95/p99 latency. Concurrent throughput continues to use the configured fixed-duration phase.
 
-For Zilliz Cloud performance runs with K above 16,384, VDBBench automatically creates new collections with `query_mode=large_topk` before creating the vector index. Reused collections are validated and rejected when that property is missing or incompatible. The selected mode and requested K are written to the run log. Other backends must already permit the requested K; VDBBench forwards K unchanged and does not alter their collection properties.
+For Milvus and Zilliz Cloud performance runs with K above 16,384, VDBBench automatically creates new collections with `query_mode=large_topk` before creating the vector index. Reused collections are validated and rejected when that property is missing or incompatible. The target database, selected mode, and requested K are written to the run log. Self-hosted Milvus must be 2.6.14 or later, the release that introduced the `query_mode=large_topk` collection property; earlier servers accept the property without honoring it. Other backends must already permit the requested K; VDBBench forwards K unchanged and does not alter their collection properties.
 
 ##### Performance Response Payloads
 

--- a/docs/release/2026-08-large-topk.md
+++ b/docs/release/2026-08-large-topk.md
@@ -24,8 +24,10 @@ Recall and NDCG now use O(K) hash lookups. A large-TopK serial run reports:
 
 Serial and concurrent latency fields are stored in seconds, matching the existing p95/p99 fields; the frontend converts them to milliseconds for display. `recall_at` values are ratios from 0 to 1. Existing result files load with zero/empty defaults for the new fields.
 
-## Zilliz Cloud Collection Mode
+## Milvus Collection Mode
 
-For Zilliz Cloud performance runs with K above 16,384, VDBBench sets `query_mode=large_topk` when it creates the collection, before creating the vector index. The run log records the requested K and selected query mode. When reusing a collection, VDBBench validates the property and fails before loading or searching if the collection is incompatible.
+For Milvus and Zilliz Cloud performance runs with K above 16,384, VDBBench sets `query_mode=large_topk` when it creates the collection, before creating the vector index. The run log records the target database, the requested K, and the selected query mode. When reusing a collection, VDBBench validates the property and fails before loading or searching if the collection is incompatible.
 
-Milvus and other backends are unchanged. Their target collection must already support the requested result count before the benchmark starts.
+Self-hosted Milvus requires 2.6.14 or later, the release that introduced the `query_mode=large_topk` collection property. Earlier servers accept the property without honoring it, so the requested K still fails against the default 16,384 limit, and the reuse check rejects the collection on the next run.
+
+Other backends are unchanged. Their target collection must already support the requested result count before the benchmark starts.

--- a/tests/test_large_topk_case.py
+++ b/tests/test_large_topk_case.py
@@ -48,8 +48,9 @@ def _large_topk_property_runner(db: DB, k: int) -> CaseRunner:
     )
 
 
-def test_zilliz_large_topk_selects_collection_mode_and_logs_requested_k(monkeypatch):
-    runner = _large_topk_property_runner(DB.ZillizCloud, 100_000)
+@pytest.mark.parametrize("db", [DB.Milvus, DB.ZillizCloud])
+def test_large_topk_selects_collection_mode_and_logs_requested_k(db, monkeypatch):
+    runner = _large_topk_property_runner(db, 100_000)
     messages = []
     monkeypatch.setattr(
         "vectordb_bench.backend.task_runner.log.info",
@@ -59,11 +60,22 @@ def test_zilliz_large_topk_selects_collection_mode_and_logs_requested_k(monkeypa
     properties = runner._collection_properties(log_selection=True)
 
     assert properties == {"query_mode": "large_topk"}
+    assert db.value in messages[0]
     assert "requested K=100000" in messages[0]
     assert "query_mode=large_topk" in messages[0]
 
 
-@pytest.mark.parametrize(("db", "k"), [(DB.ZillizCloud, 16_384), (DB.Milvus, 100_000)])
+@pytest.mark.parametrize(
+    ("db", "k"),
+    [
+        # Milvus and Zilliz Cloud stay in default mode at or below the TopK limit.
+        (DB.ZillizCloud, 16_384),
+        (DB.Milvus, 16_384),
+        (DB.Milvus, 100),
+        # Backends without a Large TopK collection mode are never reconfigured.
+        (DB.Pinecone, 100_000),
+    ],
+)
 def test_large_topk_collection_mode_does_not_change_other_workloads(db, k):
     runner = _large_topk_property_runner(db, k)
 

--- a/vectordb_bench/backend/task_runner.py
+++ b/vectordb_bench/backend/task_runner.py
@@ -29,7 +29,9 @@ from .utils import kill_proc_tree
 from .workload import WorkloadKind
 
 log = logging.getLogger(__name__)
-ZILLIZ_CLOUD_DEFAULT_TOPK_LIMIT = 16_384
+# Milvus and Zilliz Cloud cap topK at this value unless the collection opts into Large TopK mode.
+MILVUS_DEFAULT_TOPK_LIMIT = 16_384
+LARGE_TOPK_QUERY_MODE_DBS = frozenset({DB.Milvus, DB.ZillizCloud})
 
 
 class RunningStatus(Enum):
@@ -188,18 +190,19 @@ class CaseRunner(BaseModel):
     def _collection_properties(self, *, log_selection: bool = False) -> dict[str, str]:
         requested_k = self.config.case_config.k or config.K_DEFAULT
         if (
-            self.config.db != DB.ZillizCloud
+            self.config.db not in LARGE_TOPK_QUERY_MODE_DBS
             or self.ca.label != CaseLabel.Performance
-            or requested_k <= ZILLIZ_CLOUD_DEFAULT_TOPK_LIMIT
+            or requested_k <= MILVUS_DEFAULT_TOPK_LIMIT
         ):
             return {}
 
-        # Zilliz Cloud requires Large TopK mode at collection creation, before the vector index is created.
+        # Large TopK mode must be applied at collection creation, before the vector index is created.
         if log_selection:
             log.info(
-                "Zilliz Cloud requested K=%d exceeds the default TopK limit %d; using query_mode=large_topk",
+                "%s requested K=%d exceeds the default TopK limit %d; using query_mode=large_topk",
+                self.config.db.value,
                 requested_k,
-                ZILLIZ_CLOUD_DEFAULT_TOPK_LIMIT,
+                MILVUS_DEFAULT_TOPK_LIMIT,
             )
         return {"query_mode": "large_topk"}
 


### PR DESCRIPTION
I noticed that your workflow specifies a ZILLIZ_CLOUD_DEFAULT_TOPK_LIMIT restriction and then enters large_topk search mode. I think this is also necessary for open-source Milvus.