### PR TITLE
fix: ensure Milvus force merge covers compacting segments

### DIFF
--- a/tests/test_milvus.py
+++ b/tests/test_milvus.py
@@ -5,7 +5,7 @@ Requires a running Milvus instance at localhost:19530.
 
 import logging
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from pydantic import SecretStr
@@ -37,7 +37,7 @@ class TestMilvusOptimize:
         milvus.case_config = SimpleNamespace(is_gpu_index=is_gpu_index)
         milvus.client = MagicMock()
         milvus.client.compact.side_effect = compact_side_effect
-        milvus.client.compact.return_value = 0
+        milvus.client.compact.return_value = 42
         milvus._wait_for_segments_sorted = MagicMock()
         milvus._wait_for_index = MagicMock()
         milvus._wait_for_compaction = MagicMock()
@@ -48,7 +48,7 @@ class TestMilvusOptimize:
 
         milvus._optimize()
 
-        milvus.client.compact.assert_called_once_with("test_collection", target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
+        milvus.client.compact.assert_any_call("test_collection", target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
         milvus.client.refresh_load.assert_called_once_with("test_collection")
 
     def test_optimize_compacts_fts_collections(self):
@@ -56,8 +56,204 @@ class TestMilvusOptimize:
 
         milvus._optimize()
 
-        milvus.client.compact.assert_called_once_with("test_collection", target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
+        milvus.client.compact.assert_any_call("test_collection", target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
         milvus.client.refresh_load.assert_called_once_with("test_collection")
+
+    def test_optimize_flushes_and_runs_normal_compaction_before_force_merge(self):
+        milvus = self._milvus(compact_side_effect=[41, 42])
+
+        milvus._optimize()
+
+        milvus.client.flush.assert_called_once_with("test_collection")
+        assert milvus.client.compact.call_args_list == [
+            call("test_collection"),
+            call("test_collection", target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB),
+        ]
+        assert milvus._wait_for_segments_sorted.call_count == 2
+        assert milvus._wait_for_index.call_count == 3
+        assert milvus._wait_for_compaction.call_args_list == [call(41), call(42)]
+        milvus.client.refresh_load.assert_called_once_with("test_collection")
+
+    def test_optimize_retries_when_compacting_segments_are_missing_from_force_merge_plan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        class FakeMilvusClient:
+            def __init__(self):
+                self.segment_ids = [1, 2, 3]
+                self.force_merge_completed = False
+
+            def flush(self, _collection_name: str):
+                pass
+
+            def list_persistent_segments(self, _collection_name: str):
+                return [
+                    SimpleNamespace(
+                        segment_id=segment_id,
+                        is_sorted=True,
+                        state_name="Flushed",
+                        level_name="L1",
+                    )
+                    for segment_id in self.segment_ids
+                ]
+
+            def describe_index(self, _collection_name: str, _index_name: str):
+                return {"pending_index_rows": 0}
+
+            def compact(self, _collection_name: str, *, target_size: int | None = None):
+                if target_size is None:
+                    return 90
+                assert target_size == MILVUS_FORCE_MERGE_TARGET_SIZE_MB
+                if self.segment_ids == [1, 2, 3]:
+                    return 100
+                if self.segment_ids == [10, 20]:
+                    return 101
+                message = f"unexpected force merge input: {self.segment_ids}"
+                raise AssertionError(message)
+
+            def get_compaction_state(self, compaction_id: int):
+                if compaction_id == 90:
+                    pass
+                elif compaction_id == 100:
+                    self.segment_ids = [10, 20]
+                elif compaction_id == 101:
+                    self.segment_ids = [30]
+                    self.force_merge_completed = True
+                else:
+                    message = f"unexpected compaction id: {compaction_id}"
+                    raise AssertionError(message)
+                return "Completed"
+
+            def get_compaction_plans(self, compaction_id: int):
+                sources = [1] if compaction_id == 100 else [10, 20]
+                return SimpleNamespace(plans=[SimpleNamespace(sources=sources)])
+
+            def refresh_load(self, _collection_name: str):
+                assert self.force_merge_completed, "refresh started after only a partial force merge"
+
+        milvus = Milvus.__new__(Milvus)
+        milvus.name = "Milvus"
+        milvus.collection_name = "test_collection"
+        milvus._is_fts = False
+        milvus._main_index_name = "vector_idx"
+        milvus.case_config = SimpleNamespace(is_gpu_index=False)
+        milvus.client = FakeMilvusClient()
+        monkeypatch.setattr("vectordb_bench.backend.clients.milvus.milvus.time.sleep", lambda _seconds: None)
+
+        milvus.optimize(data_size=500_000)
+
+        assert milvus.client.force_merge_completed
+
+    def test_optimize_retries_when_all_segments_are_compacting(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeMilvusClient:
+            def __init__(self):
+                self.segment_ids = [1, 2]
+                self.compact_attempts = 0
+                self.force_merge_completed = False
+
+            def flush(self, _collection_name: str):
+                pass
+
+            def list_persistent_segments(self, _collection_name: str):
+                return [
+                    SimpleNamespace(
+                        segment_id=segment_id,
+                        is_sorted=True,
+                        state_name="Flushed",
+                        level_name="L1",
+                    )
+                    for segment_id in self.segment_ids
+                ]
+
+            def describe_index(self, _collection_name: str, _index_name: str):
+                return {"pending_index_rows": 0}
+
+            def compact(self, _collection_name: str, *, target_size: int | None = None):
+                if target_size is None:
+                    return 90
+                assert target_size == MILVUS_FORCE_MERGE_TARGET_SIZE_MB
+                self.compact_attempts += 1
+                if self.compact_attempts == 1:
+                    self.segment_ids = [10]
+                    return -1
+                return 101
+
+            def get_compaction_state(self, compaction_id: int):
+                if compaction_id == 90:
+                    return "Completed"
+                assert compaction_id == 101
+                self.segment_ids = [20]
+                self.force_merge_completed = True
+                return "Completed"
+
+            def get_compaction_plans(self, compaction_id: int):
+                assert compaction_id == 101
+                return SimpleNamespace(plans=[SimpleNamespace(sources=[10])])
+
+            def refresh_load(self, _collection_name: str):
+                assert self.force_merge_completed, "refresh started without a force merge job"
+
+        milvus = Milvus.__new__(Milvus)
+        milvus.name = "Milvus"
+        milvus.collection_name = "test_collection"
+        milvus._is_fts = False
+        milvus._main_index_name = "vector_idx"
+        milvus.case_config = SimpleNamespace(is_gpu_index=False)
+        milvus.client = FakeMilvusClient()
+        monkeypatch.setattr("vectordb_bench.backend.clients.milvus.milvus.time.sleep", lambda _seconds: None)
+
+        milvus.optimize(data_size=500_000)
+
+        assert milvus.client.force_merge_completed
+
+    def test_force_merge_uses_fresh_snapshots_and_stops_after_max_attempts(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeMilvusClient:
+            def __init__(self):
+                self.segment_ids = [1, 2]
+                self.compact_attempts = 0
+
+            def list_persistent_segments(self, _collection_name: str):
+                return [
+                    SimpleNamespace(
+                        segment_id=segment_id,
+                        is_sorted=True,
+                        state_name="Flushed",
+                        level_name="L1",
+                    )
+                    for segment_id in self.segment_ids
+                ]
+
+            def describe_index(self, _collection_name: str, _index_name: str):
+                return {"pending_index_rows": 0}
+
+            def compact(self, _collection_name: str, *, target_size: int):
+                assert target_size == MILVUS_FORCE_MERGE_TARGET_SIZE_MB
+                self.compact_attempts += 1
+                return 100 + self.compact_attempts
+
+            def get_compaction_state(self, _compaction_id: int):
+                next_segment_ids = {
+                    1: [10, 20],
+                    2: [30, 40],
+                    3: [50, 60],
+                }
+                self.segment_ids = next_segment_ids[self.compact_attempts]
+                return "Completed"
+
+            def get_compaction_plans(self, _compaction_id: int):
+                planned_source = {1: 1, 2: 10, 3: 30}[self.compact_attempts]
+                return SimpleNamespace(plans=[SimpleNamespace(sources=[planned_source])])
+
+        milvus = Milvus.__new__(Milvus)
+        milvus.name = "Milvus"
+        milvus.collection_name = "test_collection"
+        milvus._main_index_name = "vector_idx"
+        milvus.client = FakeMilvusClient()
+        monkeypatch.setattr("vectordb_bench.backend.clients.milvus.milvus.time.sleep", lambda _seconds: None)
+
+        with pytest.raises(RuntimeError, match=r"after 3 attempts.*missing segments: \[40\]"):
+            milvus._force_merge(max_attempts=3)
+
+        assert milvus.client.compact_attempts == 3
 
     def test_optimize_skips_gpu_index_compaction(self):
         milvus = self._milvus(is_gpu_index=True)

--- a/vectordb_bench/backend/clients/milvus/milvus.py
+++ b/vectordb_bench/backend/clients/milvus/milvus.py
@@ -19,6 +19,8 @@ log = logging.getLogger(__name__)
 MILVUS_LOAD_REQS_SIZE = 1.5 * 1024 * 1024
 MILVUS_FTS_BATCH_SIZE = 1000
 MILVUS_FORCE_MERGE_TARGET_SIZE_MB = ((1 << 63) - 1) // (1024**2)
+MILVUS_FORCE_MERGE_MAX_ATTEMPTS = 10
+MILVUS_FORCE_MERGE_RETRY_INTERVAL_SECONDS = 30
 
 
 class Milvus(VectorDB):
@@ -292,12 +294,54 @@ class Milvus(VectorDB):
                 break
             time.sleep(5)
 
+    def _wait_for_compaction_ready(self):
+        self._wait_for_segments_sorted()
+        self._wait_for_index()
+
     def _wait_for_compaction(self, compaction_id: int):
         while True:
             state = self.client.get_compaction_state(compaction_id)
             if state == "Completed":
                 break
             time.sleep(0.5)
+
+    def _force_merge_source_segment_ids(self) -> set[int]:
+        # isCompacting is not exposed by MilvusClient, so verify plan coverage
+        # against every persistent data segment that force merge should consume.
+        segments = self.client.list_persistent_segments(self.collection_name)
+        return {
+            segment.segment_id
+            for segment in segments
+            if segment.state_name == "Flushed" and segment.level_name not in {"L0", "L2"}
+        }
+
+    def _force_merge(self, max_attempts: int = MILVUS_FORCE_MERGE_MAX_ATTEMPTS):
+        if max_attempts <= 0:
+            message = "force merge max_attempts must be greater than zero"
+            raise ValueError(message)
+
+        for attempt in range(1, max_attempts + 1):
+            self._wait_for_compaction_ready()
+            expected_source_ids = self._force_merge_source_segment_ids()
+            compaction_id = self.client.compact(self.collection_name, target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
+            if compaction_id <= 0:
+                failure_detail = f"generated no plan for snapshot {sorted(expected_source_ids)}"
+            else:
+                self._wait_for_compaction(compaction_id)
+                plans = self.client.get_compaction_plans(compaction_id)
+                actual_source_ids = {source_id for plan in plans.plans for source_id in plan.sources}
+                attempt_missing_source_ids = expected_source_ids - actual_source_ids
+                if not attempt_missing_source_ids:
+                    return
+
+                failure_detail = f"missing segments: {sorted(attempt_missing_source_ids)}"
+
+            if attempt == max_attempts:
+                message = f"{self.name} force merge failed after {max_attempts} attempts; {failure_detail}"
+                raise RuntimeError(message)
+
+            log.info(f"{self.name} force merge attempt {attempt}/{max_attempts} {failure_detail}; retrying...")
+            time.sleep(MILVUS_FORCE_MERGE_RETRY_INTERVAL_SECONDS)
 
     def _optimize(self):
         log.info(f"{self.name} optimizing before search")
@@ -308,14 +352,11 @@ class Milvus(VectorDB):
                 log.debug("skip force merge compaction for gpu index type.")
             else:
                 try:
-                    # wait for sort, index, compact
-                    self._wait_for_segments_sorted()
-                    self._wait_for_index()
-                    compaction_id = self.client.compact(
-                        self.collection_name, target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB
-                    )
+                    self._wait_for_compaction_ready()
+                    compaction_id = self.client.compact(self.collection_name)
                     if compaction_id > 0:
                         self._wait_for_compaction(compaction_id)
+                    self._force_merge()
                     log.info(f"{self.name} force merge compaction completed.")
                 except Exception as e:
                     log.warning(f"{self.name} compact or list segments error: {e}")


### PR DESCRIPTION
Milvus force merge is best-effort and may skip segments already compacting. After flushing, wait for segment sorting and index readiness, run one normal manual compaction, then retry force merge with a fresh persistent segment snapshot until every segment visible for an attempt is included in its generated plans. Bound force merge to 10 attempts with a 30-second retry interval.

Add regressions for compaction ordering, partial-plan and no-plan retries, fresh per-attempt snapshots, and retry exhaustion.

See also: #784

Signed-off-by: yangxuan <xuan.yang@zilliz.com>