### PR TITLE
Make AOSS insert batch size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ OpenSearch Serverless (AOSS) is a serverless deployment option for Amazon OpenSe
 **Example: Run performance test on OpenSearch Serverless**
 
 ```shell
-vectordbbench awsopensearch --db-label aoss \
+NUM_PER_BATCH=100 vectordbbench awsopensearch --db-label aoss \
   --serverless --aws-region us-east-1 \
   --host <collection-id>.aoss.us-east-1.on.aws --port 443 \
   --case-type Performance768D1M \
@@ -303,12 +303,13 @@ OpenSearch Serverless-specific options:
 |--------|-------------|
 | `--serverless` | Enable OpenSearch Serverless mode (uses AWS SigV4 auth) |
 | `--aws-region` | AWS region for the AOSS collection (default: `us-east-1`) |
+| `NUM_PER_BATCH` | Number of vectors per Serverless bulk request (default: `100`) |
 
 > **Notes:**
 > - `--user` and `--password` are not needed for Serverless mode
 > - `--engine` is accepted but ignored internally (AOSS manages the engine)
 > - `--force-merge-enabled`, `--refresh-interval`, `--flush-threshold-size`, and `--cb-threshold` are ignored for Serverless
-> - Data insertion uses smaller batch sizes (100) for Serverless API compatibility
+> - Keep `NUM_PER_BATCH` small enough for the Serverless bulk API request limits
 
 ### Run Elastic Cloud from command line
 

--- a/tests/test_aws_opensearch.py
+++ b/tests/test_aws_opensearch.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from vectordb_bench import config
 from vectordb_bench.backend.clients.aws_opensearch.aws_opensearch import AWSOpenSearch
 
@@ -28,3 +30,17 @@ def test_serverless_insert_uses_configured_batch_size(monkeypatch) -> None:
     assert error is None
     assert [len(request) // 2 for request in bulk_requests] == [2, 2, 1]
     assert [document["id"] for request in bulk_requests for document in request[1::2]] == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_serverless_insert_rejects_non_positive_batch_size(monkeypatch, batch_size: int) -> None:
+    monkeypatch.setattr(config, "NUM_PER_BATCH", batch_size)
+
+    db = object.__new__(AWSOpenSearch)
+    db._is_serverless = True
+
+    with pytest.raises(ValueError, match="NUM_PER_BATCH must be greater than 0"):
+        db._insert_with_single_client(
+            embeddings=[[0.1]],
+            metadata=[1],
+        )

--- a/tests/test_aws_opensearch.py
+++ b/tests/test_aws_opensearch.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from vectordb_bench import config
+from vectordb_bench.backend.clients.aws_opensearch.aws_opensearch import AWSOpenSearch
+
+
+def test_serverless_insert_uses_configured_batch_size(monkeypatch) -> None:
+    bulk_requests = []
+
+    def bulk(*, body):
+        bulk_requests.append(body)
+
+    monkeypatch.setattr(config, "NUM_PER_BATCH", 2)
+
+    db = object.__new__(AWSOpenSearch)
+    db.client = SimpleNamespace(bulk=bulk)
+    db._is_serverless = True
+    db.index_name = "test-index"
+    db.vector_col_name = "embedding"
+    db.with_scalar_labels = False
+
+    inserted, error = db._insert_with_single_client(
+        embeddings=[[0.1], [0.2], [0.3], [0.4], [0.5]],
+        metadata=[1, 2, 3, 4, 5],
+    )
+
+    assert inserted == 5
+    assert error is None
+    assert [len(request) // 2 for request in bulk_requests] == [2, 2, 1]
+    assert [document["id"] for request in bulk_requests for document in request[1::2]] == [1, 2, 3, 4, 5]

--- a/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 
 from opensearchpy import OpenSearch
 
+from vectordb_bench import config
 from vectordb_bench.backend.filter import Filter, FilterOp
 
 from ..api import VectorDB
@@ -237,8 +238,8 @@ class AWSOpenSearch(VectorDB):
         num_clients = self.case_config.number_of_indexing_clients or 1
         log.info(f"Number of indexing clients from case_config: {num_clients}")
 
-        # OpenSearch Serverless requires the single-client path: it does not support
-        # custom _id and needs the benchmark id stored in _source with small batches.
+        # OpenSearch Serverless requires the single-client path because it does not
+        # support custom _id and needs the benchmark id stored in _source.
         if self._is_serverless:
             log.info("Using single client for data insertion (OpenSearch Serverless)")
             return self._insert_with_single_client(embeddings, metadata, labels_data)
@@ -256,7 +257,7 @@ class AWSOpenSearch(VectorDB):
         labels_data: list[str] | None = None,
     ) -> tuple[int, Exception]:
         embeddings_list = list(embeddings)
-        batch_size = 100 if self._is_serverless else len(embeddings_list)
+        batch_size = config.NUM_PER_BATCH if self._is_serverless else len(embeddings_list)
         total_inserted = 0
 
         for i in range(0, len(embeddings_list), batch_size):

--- a/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
+++ b/vectordb_bench/backend/clients/aws_opensearch/aws_opensearch.py
@@ -258,6 +258,8 @@ class AWSOpenSearch(VectorDB):
     ) -> tuple[int, Exception]:
         embeddings_list = list(embeddings)
         batch_size = config.NUM_PER_BATCH if self._is_serverless else len(embeddings_list)
+        if self._is_serverless and batch_size <= 0:
+            raise ValueError("NUM_PER_BATCH must be greater than 0 for OpenSearch Serverless")
         total_inserted = 0
 
         for i in range(0, len(embeddings_list), batch_size):


### PR DESCRIPTION
## What changed

- Use the existing `NUM_PER_BATCH` configuration for OpenSearch Serverless bulk requests instead of a hard-coded batch size of 100.
- Keep 100 as the default while allowing callers to override it through the environment.
- Document the environment variable and add a regression test for AOSS bulk chunking.

## Testing

```shell
PYTHONPATH=`pwd` python3 -m pytest -q tests/test_aws_opensearch.py
PYTHONPATH=`pwd` python3 -m black vectordb_bench
PYTHONPATH=`pwd` python3 -m ruff check vectordb_bench --fix
PYTHONPATH=`pwd` python3 -m black vectordb_bench --check
PYTHONPATH=`pwd` python3 -m ruff check vectordb_bench
```