### PR TITLE
fix: include exact in MongoDB search_param

### DIFF
--- a/tests/test_mongodb_config.py
+++ b/tests/test_mongodb_config.py
@@ -1,10 +1,27 @@
-"""Offline unit tests for MongoDBIndexConfig.search_param().
+"""Offline unit tests for MongoDBIndexConfig.search_param() and search_embedding.
 
 mongodb.py indexes search_params["exact"] on every query. These tests freeze
-that contract so a missing key cannot regress into a KeyError.
+that contract so a missing key cannot regress into a KeyError, and they drive
+search_embedding with a mocked collection (no live MongoDB).
 """
 
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+try:
+    import pymongo  # noqa: F401
+except ImportError:
+    _pymongo = types.ModuleType("pymongo")
+    _pymongo.MongoClient = MagicMock
+    _ops = types.ModuleType("pymongo.operations")
+    _ops.SearchIndexModel = MagicMock
+    sys.modules["pymongo"] = _pymongo
+    sys.modules["pymongo.operations"] = _ops
+
 from vectordb_bench.backend.clients.mongodb.config import MongoDBIndexConfig
+from vectordb_bench.backend.clients.mongodb.mongodb import MongoDB
 
 
 def test_search_param_includes_exact_default_false():
@@ -17,3 +34,42 @@ def test_search_param_forwards_exact_true():
     params = MongoDBIndexConfig(exact=True).search_param()
     assert params["exact"] is True
     assert params["num_candidates_ratio"] == 10
+
+
+def _client(case_config=None):
+    db = MongoDB.__new__(MongoDB)
+    db.vector_field = "vector"
+    db.id_field = "id"
+    db.case_config = case_config or MongoDBIndexConfig()
+    db.collection = MagicMock()
+    db.collection.aggregate.return_value = [{"id": 7}, {"id": 8}]
+    return db
+
+
+def test_search_embedding_default_uses_num_candidates():
+    db = _client()
+    ids = db.search_embedding([0.1, 0.2], k=100)
+    assert ids == [7, 8]
+    vector_search = db.collection.aggregate.call_args[0][0][0]["$vectorSearch"]
+    assert "exact" not in vector_search
+    assert vector_search["numCandidates"] == 1000  # min(10000, k * ratio)
+    assert vector_search["limit"] == 100
+    assert vector_search["queryVector"] == [0.1, 0.2]
+
+
+def test_search_embedding_exact_true_omits_num_candidates():
+    db = _client(MongoDBIndexConfig(exact=True))
+    db.search_embedding([0.1, 0.2], k=10)
+    vector_search = db.collection.aggregate.call_args[0][0][0]["$vectorSearch"]
+    assert vector_search["exact"] is True
+    assert "numCandidates" not in vector_search
+
+
+def test_search_embedding_missing_exact_key_is_ann():
+    """.get("exact") must not KeyError if a case config omits the key."""
+    cfg = SimpleNamespace(search_param=lambda: {"num_candidates_ratio": 10})
+    db = _client(cfg)
+    db.search_embedding([0.1, 0.2], k=50)
+    vector_search = db.collection.aggregate.call_args[0][0][0]["$vectorSearch"]
+    assert "exact" not in vector_search
+    assert vector_search["numCandidates"] == 500

--- a/tests/test_mongodb_config.py
+++ b/tests/test_mongodb_config.py
@@ -1,0 +1,19 @@
+"""Offline unit tests for MongoDBIndexConfig.search_param().
+
+mongodb.py indexes search_params["exact"] on every query. These tests freeze
+that contract so a missing key cannot regress into a KeyError.
+"""
+
+from vectordb_bench.backend.clients.mongodb.config import MongoDBIndexConfig
+
+
+def test_search_param_includes_exact_default_false():
+    params = MongoDBIndexConfig().search_param()
+    assert params["exact"] is False
+    assert params["num_candidates_ratio"] == 10
+
+
+def test_search_param_forwards_exact_true():
+    params = MongoDBIndexConfig(exact=True).search_param()
+    assert params["exact"] is True
+    assert params["num_candidates_ratio"] == 10

--- a/tests/test_mongodb_config.py
+++ b/tests/test_mongodb_config.py
@@ -20,8 +20,16 @@ except ImportError:
     sys.modules["pymongo"] = _pymongo
     sys.modules["pymongo.operations"] = _ops
 
-from vectordb_bench.backend.clients.mongodb.config import MongoDBIndexConfig
+from vectordb_bench.backend.cases import CaseLabel, CaseType
+from vectordb_bench.backend.clients import DB
+from vectordb_bench.backend.clients.mongodb.config import MongoDBConfig, MongoDBIndexConfig
 from vectordb_bench.backend.clients.mongodb.mongodb import MongoDB
+from vectordb_bench.frontend.components.run_test.generateTasks import generate_tasks
+from vectordb_bench.frontend.config.dbCaseConfigs import (
+    MongoDBPerformanceConfig,
+    get_case_config_inputs,
+)
+from vectordb_bench.models import CaseConfig, CaseConfigParamType
 
 
 def test_search_param_includes_exact_default_false():
@@ -73,3 +81,42 @@ def test_search_embedding_missing_exact_key_is_ann():
     vector_search = db.collection.aggregate.call_args[0][0][0]["$vectorSearch"]
     assert "exact" not in vector_search
     assert vector_search["numCandidates"] == 500
+
+
+def test_performance_ui_exposes_exact_default_false():
+    labels = [c.label for c in MongoDBPerformanceConfig]
+    assert CaseConfigParamType.mongodb_exact in labels
+    exact = next(c for c in MongoDBPerformanceConfig if c.label == CaseConfigParamType.mongodb_exact)
+    assert exact.inputConfig["value"] is False
+    perf_inputs = get_case_config_inputs(DB.MongoDB, CaseLabel.Performance)
+    assert CaseConfigParamType.mongodb_exact in [c.label for c in perf_inputs]
+
+
+def _tasks_from_ui(overrides=None):
+    case = CaseConfig(case_id=CaseType.Performance1536D50K)
+    ui = {
+        CaseConfigParamType.mongodb_quantization_type: "none",
+        CaseConfigParamType.mongodb_num_candidates_ratio: 10,
+        CaseConfigParamType.mongodb_exact: False,
+    }
+    if overrides:
+        ui.update(overrides)
+    return generate_tasks(
+        [DB.MongoDB],
+        {DB.MongoDB: MongoDBConfig()},
+        [case],
+        {DB.MongoDB: {case: ui}},
+    )
+
+
+def test_generate_tasks_forwards_exact_false_by_default():
+    tasks = _tasks_from_ui()
+    assert len(tasks) == 1
+    assert tasks[0].db_case_config.exact is False
+    assert tasks[0].db_case_config.search_param()["exact"] is False
+
+
+def test_generate_tasks_forwards_exact_true_from_ui():
+    tasks = _tasks_from_ui({CaseConfigParamType.mongodb_exact: True})
+    assert tasks[0].db_case_config.exact is True
+    assert tasks[0].db_case_config.search_param()["exact"] is True

--- a/vectordb_bench/backend/clients/mongodb/config.py
+++ b/vectordb_bench/backend/clients/mongodb/config.py
@@ -27,6 +27,7 @@ class MongoDBIndexConfig(BaseModel, DBCaseConfig):
     metric_type: MetricType = MetricType.COSINE
     num_candidates_ratio: int = 10  # Default numCandidates ratio for vector search
     quantization: QuantizationType = QuantizationType.NONE  # Quantization type if applicable
+    exact: bool = False  # Atlas $vectorSearch exact (ENN); default ANN
 
     def parse_metric(self) -> str:
         if self.metric_type == MetricType.L2:
@@ -50,4 +51,7 @@ class MongoDBIndexConfig(BaseModel, DBCaseConfig):
         }
 
     def search_param(self) -> dict:
-        return {"num_candidates_ratio": self.num_candidates_ratio}
+        return {
+            "num_candidates_ratio": self.num_candidates_ratio,
+            "exact": self.exact,
+        }

--- a/vectordb_bench/backend/clients/mongodb/mongodb.py
+++ b/vectordb_bench/backend/clients/mongodb/mongodb.py
@@ -162,7 +162,7 @@ class MongoDB(VectorDB):
         vector_search = {"queryVector": query, "index": "vector_index", "path": self.vector_field, "limit": k}
 
         # Add exact search parameter if specified
-        if search_params["exact"]:
+        if search_params.get("exact"):
             vector_search["exact"] = True
         else:
             # Set numCandidates based on k value and data size

--- a/vectordb_bench/frontend/config/dbCaseConfigs.py
+++ b/vectordb_bench/frontend/config/dbCaseConfigs.py
@@ -1880,6 +1880,16 @@ CaseConfigParamInput_MongoDBNumCandidatesRatio = CaseConfigInput(
     },
 )
 
+CaseConfigParamInput_MongoDBExact = CaseConfigInput(
+    label=CaseConfigParamType.mongodb_exact,
+    inputType=InputType.Bool,
+    displayLabel="Exact (ENN)",
+    inputHelp="Atlas $vectorSearch exact nearest neighbor. Default False keeps ANN.",
+    inputConfig={
+        "value": False,
+    },
+)
+
 
 CaseConfigParamInput_M_Vespa = CaseConfigInput(
     label=CaseConfigParamType.M,
@@ -2532,6 +2542,7 @@ MongoDBLoadingConfig = [
 MongoDBPerformanceConfig = [
     CaseConfigParamInput_MongoDBQuantizationType,
     CaseConfigParamInput_MongoDBNumCandidatesRatio,
+    CaseConfigParamInput_MongoDBExact,
 ]
 
 CockroachDBLoadingConfig = [

--- a/vectordb_bench/models.py
+++ b/vectordb_bench/models.py
@@ -135,6 +135,7 @@ class CaseConfigParamType(Enum):
     metric_type_name = "metric_type_name"
     mongodb_quantization_type = "quantization"
     mongodb_num_candidates_ratio = "num_candidates_ratio"
+    mongodb_exact = "exact"
     use_partition_key = "use_partition_key"
     refresh_interval = "refresh_interval"
     use_rescore = "use_rescore"


### PR DESCRIPTION
## Summary

MongoDB search crashes on every query with `KeyError: 'exact'`. `search_embedding` indexes `search_params["exact"]`, but `MongoDBIndexConfig.search_param()` only returned `num_candidates_ratio`.

This adds `exact: bool = False` and emits it from `search_param()`, and reads the key with `.get("exact")`. The default stays ANN (`numCandidates`). `exact=True` enables Atlas `$vectorSearch` ENN.

The MongoDB performance UI now has a Boolean Exact (ENN) input, default False, so frontend task generation can select ENN.

## How to test

CI `make unittest` is a single network download and will not run this file.

```bash
pip install -e '.[test]'
make lint
PYTHONPATH=. python3 -m pytest tests/test_mongodb_config.py tests/test_db_client_resolution.py -q
```
