### PR TITLE
fix: wire MongoDB label filters through prepare_filter

### DIFF
--- a/tests/test_mongodb_client.py
+++ b/tests/test_mongodb_client.py
@@ -138,3 +138,91 @@ def test_create_index_omits_label_filter_without_scalar_labels():
     collection.list_search_indexes.side_effect = _ready_search_indexes()
     client._create_index()
     assert not any(field.get("type") == "filter" for field in client.index_params["fields"])
+
+
+def test_filter_supported_matches_assembler_contract():
+    assert MongoDB.filter_supported(NonFilter()) is True
+    assert MongoDB.filter_supported(LabelFilter(label_percentage=0.25)) is True
+    assert MongoDB.filter_supported(IntFilter(int_value=500, filter_rate=0.99)) is False
+
+
+def test_insert_embeddings_accepts_runner_kwargs():
+    client, collection = _make_client(with_scalar_labels=True)
+    insert_kwargs = {
+        "embeddings": [[0.1, 0.2, 0.3, 0.4]],
+        "metadata": [7],
+        "labels_data": ["label_5p"],
+    }
+    count, err = client.insert_embeddings(**insert_kwargs)
+    assert err is None
+    assert count == 1
+    documents, kwargs = collection.insert_many.call_args[0][0], collection.insert_many.call_args[1]
+    assert documents[0]["label"] == "label_5p"
+    assert kwargs["ordered"] is False
+
+
+def test_insert_embeddings_omits_label_when_labels_data_missing():
+    client, collection = _make_client(with_scalar_labels=True)
+    client.insert_embeddings(embeddings=[[0.1, 0.2, 0.3, 0.4]], metadata=[1])
+    documents = collection.insert_many.call_args[0][0]
+    assert "label" not in documents[0]
+
+
+def test_insert_embeddings_returns_error_from_insert_many():
+    client, collection = _make_client()
+    collection.insert_many.side_effect = RuntimeError("bulk write failed")
+    count, err = client.insert_embeddings([[0.1, 0.2, 0.3, 0.4]], [1])
+    assert count == 0
+    assert isinstance(err, RuntimeError)
+
+
+def test_search_embedding_ignores_filters_kwarg():
+    # Old client applied filters={"id": ...} here. Runners never pass that;
+    # leftover callers must not resurrect the unfiltered/wrong-gte path.
+    client, collection = _make_client(with_scalar_labels=True)
+    collection.aggregate.return_value = [{"id": 1}]
+    client.prepare_filter(LabelFilter(label_percentage=0.25))
+    client.search_embedding([0.1, 0.2, 0.3, 0.4], k=10, filters={"id": 500})
+    pipeline = collection.aggregate.call_args[0][0]
+    assert pipeline[0]["$vectorSearch"]["filter"] == {"label": "label_25p"}
+    assert "gte" not in str(pipeline[0]["$vectorSearch"]["filter"])
+
+
+def test_search_embedding_sets_num_candidates_for_ann():
+    client, collection = _make_client()
+    collection.aggregate.return_value = [{"id": 3}, {"id": 1}]
+    ids = client.search_embedding([0.1, 0.2, 0.3, 0.4], k=10)
+    assert ids == [3, 1]
+    vector_search = collection.aggregate.call_args[0][0][0]["$vectorSearch"]
+    assert vector_search["limit"] == 10
+    assert vector_search["numCandidates"] == 100
+    assert "exact" not in vector_search
+    assert "filter" not in vector_search
+
+
+def test_create_index_does_not_duplicate_label_filter_field():
+    client, collection = _make_client(with_scalar_labels=True)
+    collection.list_indexes.return_value = [True]
+    collection.list_search_indexes.side_effect = [
+        [],
+        [{"name": "vector_index", "queryable": True}],
+        [],
+        [{"name": "vector_index", "queryable": True}],
+    ]
+    client._create_index()
+    client._create_index()
+    fields = [field for field in client.index_params["fields"] if field.get("type") == "filter"]
+    assert fields == [{"type": "filter", "path": "label"}]
+
+
+def test_optimize_declares_label_filter_on_search_index():
+    client, collection = _make_client(with_scalar_labels=True)
+    collection.list_indexes.return_value = [True]
+    collection.list_search_indexes.side_effect = [
+        [],
+        [{"name": "vector_index", "queryable": True}],
+        [{"name": "vector_index", "queryable": True}],
+    ]
+    client.optimize()
+    model = collection.create_search_index.call_args[0][0]
+    assert {"type": "filter", "path": "label"} in model.document["definition"]["fields"]

--- a/tests/test_mongodb_client.py
+++ b/tests/test_mongodb_client.py
@@ -1,0 +1,140 @@
+"""Offline unit tests for MongoDB label-filter wiring.
+
+Runners call prepare_filter(filters) then search_embedding(query, k) — they
+never pass filters= into search. Atlas also requires {type: "filter", path:
+"label"} on the vector search index. These tests mock insert_many / aggregate
+so they do not need a live MongoDB.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vectordb_bench.backend.clients.mongodb.config import MongoDBIndexConfig
+from vectordb_bench.backend.clients.mongodb.mongodb import MongoDB
+from vectordb_bench.backend.filter import FilterOp, IntFilter, LabelFilter, NonFilter
+
+_DB_CONFIG = {
+    "connection_string": "mongodb://localhost:27017",
+    "database": "vdb_bench",
+}
+
+
+class _IndexConfig(MongoDBIndexConfig):
+    """main's search_param() omits exact (sibling PR). Search tests need the key."""
+
+    def search_param(self) -> dict:
+        params = super().search_param()
+        params.setdefault("exact", False)
+        return params
+
+
+def _make_client(with_scalar_labels: bool = False):
+    mock_client = MagicMock()
+    mock_db = MagicMock()
+    mock_collection = MagicMock()
+    mock_client.__getitem__.return_value = mock_db
+    mock_db.__getitem__.return_value = mock_collection
+    mock_db.list_collection_names.return_value = []
+
+    with patch(
+        "vectordb_bench.backend.clients.mongodb.mongodb.MongoClient",
+        return_value=mock_client,
+    ):
+        client = MongoDB(
+            dim=4,
+            db_config=_DB_CONFIG,
+            db_case_config=_IndexConfig(),
+            drop_old=False,
+            with_scalar_labels=with_scalar_labels,
+        )
+    client.collection = mock_collection
+    client.client = mock_client
+    client.db = mock_db
+    return client, mock_collection
+
+
+def test_supported_filter_types_include_str_equal():
+    assert MongoDB.supported_filter_types == [FilterOp.NonFilter, FilterOp.StrEqual]
+
+
+def test_insert_embeddings_writes_label_when_with_scalar_labels():
+    client, collection = _make_client(with_scalar_labels=True)
+    count, err = client.insert_embeddings(
+        embeddings=[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]],
+        metadata=[1, 2],
+        labels_data=["label_25p", "label_50p"],
+    )
+    assert err is None
+    assert count == 2
+    documents = collection.insert_many.call_args[0][0]
+    assert documents[0]["label"] == "label_25p"
+    assert documents[1]["label"] == "label_50p"
+    assert documents[0]["id"] == 1
+    assert documents[0]["vector"] == [0.1, 0.2, 0.3, 0.4]
+
+
+def test_insert_embeddings_omits_label_without_scalar_labels():
+    client, collection = _make_client(with_scalar_labels=False)
+    client.insert_embeddings(
+        embeddings=[[0.1, 0.2, 0.3, 0.4]],
+        metadata=[1],
+        labels_data=["label_25p"],
+    )
+    documents = collection.insert_many.call_args[0][0]
+    assert "label" not in documents[0]
+
+
+def test_search_embedding_applies_label_filter_after_prepare_filter():
+    # Regression: runners never pass filters= into search_embedding.
+    client, collection = _make_client(with_scalar_labels=True)
+    collection.aggregate.return_value = [{"id": 1}]
+    client.prepare_filter(LabelFilter(label_percentage=0.25))
+    ids = client.search_embedding([0.1, 0.2, 0.3, 0.4], k=10)
+    assert ids == [1]
+    pipeline = collection.aggregate.call_args[0][0]
+    assert pipeline[0]["$vectorSearch"]["filter"] == {"label": "label_25p"}
+
+
+def test_prepare_filter_nonfilter_clears_label_filter():
+    client, collection = _make_client(with_scalar_labels=True)
+    collection.aggregate.return_value = [{"id": 1}]
+    client.prepare_filter(LabelFilter(label_percentage=0.25))
+    client.prepare_filter(NonFilter())
+    client.search_embedding([0.1, 0.2, 0.3, 0.4], k=10)
+    pipeline = collection.aggregate.call_args[0][0]
+    assert "filter" not in pipeline[0]["$vectorSearch"]
+
+
+def test_prepare_filter_rejects_numge():
+    client, _ = _make_client()
+    with pytest.raises(ValueError, match="(?i)not support|NumGE"):
+        client.prepare_filter(IntFilter(int_value=500, filter_rate=0.99))
+
+
+def _ready_search_indexes():
+    return [
+        [],
+        [{"name": "vector_index", "queryable": True}],
+        [{"name": "vector_index", "queryable": True}],
+    ]
+
+
+def test_create_index_declares_label_filter_when_with_scalar_labels():
+    client, collection = _make_client(with_scalar_labels=True)
+    collection.list_indexes.return_value = [True]
+    collection.list_search_indexes.side_effect = _ready_search_indexes()
+    client._create_index()
+    fields = client.index_params["fields"]
+    assert {"type": "filter", "path": "label"} in fields
+    collection.create_search_index.assert_called_once()
+    model = collection.create_search_index.call_args[0][0]
+    assert {"type": "filter", "path": "label"} in model.document["definition"]["fields"]
+
+
+def test_create_index_omits_label_filter_without_scalar_labels():
+    client, collection = _make_client(with_scalar_labels=False)
+    collection.list_indexes.return_value = [True]
+    collection.list_search_indexes.side_effect = _ready_search_indexes()
+    client._create_index()
+    assert not any(field.get("type") == "filter" for field in client.index_params["fields"])

--- a/tests/test_mongodb_client.py
+++ b/tests/test_mongodb_client.py
@@ -20,15 +20,6 @@ _DB_CONFIG = {
 }
 
 
-class _IndexConfig(MongoDBIndexConfig):
-    """main's search_param() omits exact (sibling PR). Search tests need the key."""
-
-    def search_param(self) -> dict:
-        params = super().search_param()
-        params.setdefault("exact", False)
-        return params
-
-
 def _make_client(with_scalar_labels: bool = False):
     mock_client = MagicMock()
     mock_db = MagicMock()
@@ -44,7 +35,7 @@ def _make_client(with_scalar_labels: bool = False):
         client = MongoDB(
             dim=4,
             db_config=_DB_CONFIG,
-            db_case_config=_IndexConfig(),
+            db_case_config=MongoDBIndexConfig(),
             drop_old=False,
             with_scalar_labels=with_scalar_labels,
         )

--- a/tests/test_mongodb_config.py
+++ b/tests/test_mongodb_config.py
@@ -1,10 +1,27 @@
-"""Offline unit tests for MongoDBIndexConfig.search_param().
+"""Offline unit tests for MongoDBIndexConfig.search_param() and search_embedding.
 
 mongodb.py indexes search_params["exact"] on every query. These tests freeze
-that contract so a missing key cannot regress into a KeyError.
+that contract so a missing key cannot regress into a KeyError, and they drive
+search_embedding with a mocked collection (no live MongoDB).
 """
 
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+try:
+    import pymongo  # noqa: F401
+except ImportError:
+    _pymongo = types.ModuleType("pymongo")
+    _pymongo.MongoClient = MagicMock
+    _ops = types.ModuleType("pymongo.operations")
+    _ops.SearchIndexModel = MagicMock
+    sys.modules["pymongo"] = _pymongo
+    sys.modules["pymongo.operations"] = _ops
+
 from vectordb_bench.backend.clients.mongodb.config import MongoDBIndexConfig
+from vectordb_bench.backend.clients.mongodb.mongodb import MongoDB
 
 
 def test_search_param_includes_exact_default_false():
@@ -17,3 +34,42 @@ def test_search_param_forwards_exact_true():
     params = MongoDBIndexConfig(exact=True).search_param()
     assert params["exact"] is True
     assert params["num_candidates_ratio"] == 10
+
+
+def _client(case_config=None):
+    db = MongoDB.__new__(MongoDB)
+    db.vector_field = "vector"
+    db.id_field = "id"
+    db.case_config = case_config or MongoDBIndexConfig()
+    db.collection = MagicMock()
+    db.collection.aggregate.return_value = [{"id": 7}, {"id": 8}]
+    return db
+
+
+def test_search_embedding_default_uses_num_candidates():
+    db = _client()
+    ids = db.search_embedding([0.1, 0.2], k=100)
+    assert ids == [7, 8]
+    vector_search = db.collection.aggregate.call_args[0][0][0]["$vectorSearch"]
+    assert "exact" not in vector_search
+    assert vector_search["numCandidates"] == 1000  # min(10000, k * ratio)
+    assert vector_search["limit"] == 100
+    assert vector_search["queryVector"] == [0.1, 0.2]
+
+
+def test_search_embedding_exact_true_omits_num_candidates():
+    db = _client(MongoDBIndexConfig(exact=True))
+    db.search_embedding([0.1, 0.2], k=10)
+    vector_search = db.collection.aggregate.call_args[0][0][0]["$vectorSearch"]
+    assert vector_search["exact"] is True
+    assert "numCandidates" not in vector_search
+
+
+def test_search_embedding_missing_exact_key_is_ann():
+    """.get("exact") must not KeyError if a case config omits the key."""
+    cfg = SimpleNamespace(search_param=lambda: {"num_candidates_ratio": 10})
+    db = _client(cfg)
+    db.search_embedding([0.1, 0.2], k=50)
+    vector_search = db.collection.aggregate.call_args[0][0][0]["$vectorSearch"]
+    assert "exact" not in vector_search
+    assert vector_search["numCandidates"] == 500

--- a/tests/test_mongodb_config.py
+++ b/tests/test_mongodb_config.py
@@ -1,0 +1,19 @@
+"""Offline unit tests for MongoDBIndexConfig.search_param().
+
+mongodb.py indexes search_params["exact"] on every query. These tests freeze
+that contract so a missing key cannot regress into a KeyError.
+"""
+
+from vectordb_bench.backend.clients.mongodb.config import MongoDBIndexConfig
+
+
+def test_search_param_includes_exact_default_false():
+    params = MongoDBIndexConfig().search_param()
+    assert params["exact"] is False
+    assert params["num_candidates_ratio"] == 10
+
+
+def test_search_param_forwards_exact_true():
+    params = MongoDBIndexConfig(exact=True).search_param()
+    assert params["exact"] is True
+    assert params["num_candidates_ratio"] == 10

--- a/tests/test_mongodb_config.py
+++ b/tests/test_mongodb_config.py
@@ -41,6 +41,7 @@ def _client(case_config=None):
     db.vector_field = "vector"
     db.id_field = "id"
     db.case_config = case_config or MongoDBIndexConfig()
+    db._search_filter = None
     db.collection = MagicMock()
     db.collection.aggregate.return_value = [{"id": 7}, {"id": 8}]
     return db

--- a/vectordb_bench/backend/clients/mongodb/config.py
+++ b/vectordb_bench/backend/clients/mongodb/config.py
@@ -27,6 +27,7 @@ class MongoDBIndexConfig(BaseModel, DBCaseConfig):
     metric_type: MetricType = MetricType.COSINE
     num_candidates_ratio: int = 10  # Default numCandidates ratio for vector search
     quantization: QuantizationType = QuantizationType.NONE  # Quantization type if applicable
+    exact: bool = False  # Atlas $vectorSearch exact (ENN); default ANN
 
     def parse_metric(self) -> str:
         if self.metric_type == MetricType.L2:
@@ -50,4 +51,7 @@ class MongoDBIndexConfig(BaseModel, DBCaseConfig):
         }
 
     def search_param(self) -> dict:
-        return {"num_candidates_ratio": self.num_candidates_ratio}
+        return {
+            "num_candidates_ratio": self.num_candidates_ratio,
+            "exact": self.exact,
+        }

--- a/vectordb_bench/backend/clients/mongodb/mongodb.py
+++ b/vectordb_bench/backend/clients/mongodb/mongodb.py
@@ -162,7 +162,7 @@ class MongoDB(VectorDB):
         vector_search = {"queryVector": query, "index": "vector_index", "path": self.vector_field, "limit": k}
 
         # Add exact search parameter if specified
-        if search_params["exact"]:
+        if search_params.get("exact"):
             vector_search["exact"] = True
         else:
             # Set numCandidates based on k value and data size

--- a/vectordb_bench/backend/clients/mongodb/mongodb.py
+++ b/vectordb_bench/backend/clients/mongodb/mongodb.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager
 from pymongo import MongoClient
 from pymongo.operations import SearchIndexModel
 
+from vectordb_bench.backend.filter import Filter, FilterOp
+
 from ..api import VectorDB
 from .config import MongoDBIndexConfig
 
@@ -16,6 +18,11 @@ class MongoDBError(Exception):
 
 
 class MongoDB(VectorDB):
+    supported_filter_types: list[FilterOp] = [
+        FilterOp.NonFilter,
+        FilterOp.StrEqual,
+    ]
+
     def __init__(
         self,
         dim: int,
@@ -25,6 +32,7 @@ class MongoDB(VectorDB):
         id_field: str = "id",
         vector_field: str = "vector",
         drop_old: bool = False,
+        with_scalar_labels: bool = False,
         **kwargs,
     ):
         self.dim = dim
@@ -34,6 +42,9 @@ class MongoDB(VectorDB):
         self.id_field = id_field
         self.vector_field = vector_field
         self.drop_old = drop_old
+        self.with_scalar_labels = with_scalar_labels
+        self._scalar_label_field = "label"
+        self._search_filter: dict | None = None
 
         # Update index dimensions
         index_params = self.case_config.index_param()
@@ -91,6 +102,13 @@ class MongoDB(VectorDB):
                         log.info(f"index deleting {indices}")
                 except Exception:
                     log.exception(f"Error dropping index {index_name}")
+        if self.with_scalar_labels:
+            fields = list(self.index_params.get("fields", []))
+            label_filter = {"type": "filter", "path": self._scalar_label_field}
+            if label_filter not in fields:
+                fields.append(label_filter)
+                self.index_params = {**self.index_params, "fields": fields}
+            index_params = self.index_params
         try:
             # Create vector search index
             search_index = SearchIndexModel(definition=index_params, name=index_name, type="vectorSearch")
@@ -129,18 +147,20 @@ class MongoDB(VectorDB):
         self,
         embeddings: list[list[float]],
         metadata: list[int],
+        labels_data: list[str] | None = None,
         **kwargs,
     ) -> (int, Exception | None):
         """Insert embeddings into MongoDB"""
 
-        # Prepare documents in bulk
-        documents = [
-            {
+        documents = []
+        for i, (id_, embedding) in enumerate(zip(metadata, embeddings, strict=False)):
+            doc = {
                 self.id_field: id_,
                 self.vector_field: embedding,
             }
-            for id_, embedding in zip(metadata, embeddings, strict=False)
-        ]
+            if self.with_scalar_labels and labels_data is not None:
+                doc[self._scalar_label_field] = labels_data[i]
+            documents.append(doc)
 
         # Use ordered=False for better insert performance
         try:
@@ -149,11 +169,19 @@ class MongoDB(VectorDB):
             return 0, e
         return len(documents), None
 
+    def prepare_filter(self, filters: Filter):
+        if filters.type == FilterOp.NonFilter:
+            self._search_filter = None
+        elif filters.type == FilterOp.StrEqual:
+            self._search_filter = {self._scalar_label_field: filters.label_value}
+        else:
+            msg = f"Not support Filter for MongoDB - {filters}"
+            raise ValueError(msg)
+
     def search_embedding(
         self,
         query: list[float],
         k: int = 100,
-        filters: dict | None = None,
         **kwargs,
     ) -> list[int]:
         """Search for similar vectors"""
@@ -170,12 +198,8 @@ class MongoDB(VectorDB):
             num_candidates = min(10000, k * search_params["num_candidates_ratio"])
             vector_search["numCandidates"] = num_candidates
 
-        # Add filter if specified
-        if filters:
-            log.info(f"Applying filter: {filters}")
-            vector_search["filter"] = {
-                "id": {"gte": filters["id"]},
-            }
+        if self._search_filter is not None:
+            vector_search["filter"] = self._search_filter
         pipeline = [
             {"$vectorSearch": vector_search},
             {


### PR DESCRIPTION
## Summary

MongoDB label-filter cases were silently unfiltered (recall ~0.111 vs ~0.982 once labels actually reach `$vectorSearch`). The runner already passes `labels_data=` into insert and calls `prepare_filter` then `search_embedding(query, k)`. It never passes `filters=` into search. This wires the four missing pieces, matching `qdrant_cloud`:

- declare `supported_filter_types = [NonFilter, StrEqual]` so label cases are not skipped
- persist `labels_data` on documents as `label` when `with_scalar_labels`
- `prepare_filter` stashes `{label: <value>}` for search to apply
- add `{type: "filter", path: "label"}` to the vector search index when `with_scalar_labels` (Atlas rejects undeclared filter paths)

Does not add ingest-once `metadata_fields`, dict `labels_data`, or `NumGE`.

Rebased onto #852 so production `MongoDBIndexConfig.search_param()` includes `exact`. Filter tests construct `MongoDBIndexConfig()` rather than a stub subclass.

## How to test

```bash
PYTHONPATH=. python3 -m pytest tests/test_mongodb_client.py tests/test_mongodb_config.py -q
make lint
```

`make unittest` is the network dataset download only and does not run these files.

21 passed. `make lint` clean. `tests/test_db_client_resolution.py` 43 passed.
