### PR TITLE
fix milvus forceMerge support targetSize config

### DIFF
--- a/tests/test_milvus.py
+++ b/tests/test_milvus.py
@@ -8,13 +8,21 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 
 import pytest
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 from vectordb_bench.backend.cases import CaseType
 from vectordb_bench.backend.clients import DB
 from vectordb_bench.backend.clients.api import IndexType
-from vectordb_bench.backend.clients.milvus.config import MilvusConfig
-from vectordb_bench.backend.clients.milvus.milvus import MILVUS_FORCE_MERGE_TARGET_SIZE_MB, Milvus
+from vectordb_bench.backend.clients.milvus.config import (
+    MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB,
+    AutoIndexConfig,
+    MilvusConfig,
+)
+from vectordb_bench.backend.clients.milvus.milvus import (
+    MILVUS_FORCE_MERGE_TARGET_SIZE_MB,
+    Milvus,
+    resolve_force_merge_target_size_mb,
+)
 from vectordb_bench.backend.payload import PayloadProfile
 from vectordb_bench.interface import BenchMarkRunner
 from vectordb_bench.models import CaseConfig, TaskConfig
@@ -29,11 +37,13 @@ class TestMilvusOptimize:
         compact_side_effect: Exception | None = None,
         is_fts: bool = False,
         is_gpu_index: bool = False,
+        force_merge_target_size_mb: int = MILVUS_FORCE_MERGE_TARGET_SIZE_MB,
     ):
         milvus = Milvus.__new__(Milvus)
         milvus.name = "Milvus"
         milvus.collection_name = "test_collection"
         milvus._is_fts = is_fts
+        milvus.force_merge_target_size_mb = force_merge_target_size_mb
         milvus.case_config = SimpleNamespace(is_gpu_index=is_gpu_index)
         milvus.client = MagicMock()
         milvus.client.compact.side_effect = compact_side_effect
@@ -50,6 +60,41 @@ class TestMilvusOptimize:
 
         milvus.client.compact.assert_any_call("test_collection", target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
         milvus.client.refresh_load.assert_called_once_with("test_collection")
+
+    def test_optimize_compact_uses_configured_force_merge_target_size(self):
+        milvus = self._milvus(force_merge_target_size_mb=1024)
+
+        milvus._optimize()
+
+        assert milvus.client.compact.call_args_list == [
+            call("test_collection"),
+            call("test_collection", target_size=1024),
+        ]
+        milvus.client.refresh_load.assert_called_once_with("test_collection")
+
+    def test_force_merge_with_bounded_target_size_does_not_require_full_plan_coverage(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # a bounded target size lets the server skip segments that already reached it,
+        # so a partial plan must not fail the run
+        sleeps = []
+        monkeypatch.setattr(
+            "vectordb_bench.backend.clients.milvus.milvus.time.sleep",
+            lambda seconds: sleeps.append(seconds),
+        )
+        milvus = self._milvus(force_merge_target_size_mb=1024)
+        milvus.client.list_persistent_segments.return_value = [
+            SimpleNamespace(segment_id=1, is_sorted=True, state_name="Flushed", level_name="L1"),
+            SimpleNamespace(segment_id=2, is_sorted=True, state_name="Flushed", level_name="L1"),
+        ]
+        milvus.client.get_compaction_plans.return_value = SimpleNamespace(plans=[SimpleNamespace(sources=[1])])
+
+        milvus._force_merge()
+
+        milvus.client.compact.assert_called_once_with("test_collection", target_size=1024)
+        milvus._wait_for_compaction.assert_called_once_with(42)
+        milvus.client.get_compaction_plans.assert_not_called()
+        assert sleeps == []
 
     def test_optimize_compacts_fts_collections(self):
         milvus = self._milvus(is_fts=True)
@@ -135,6 +180,7 @@ class TestMilvusOptimize:
         milvus.collection_name = "test_collection"
         milvus._is_fts = False
         milvus._main_index_name = "vector_idx"
+        milvus.force_merge_target_size_mb = MILVUS_FORCE_MERGE_TARGET_SIZE_MB
         milvus.case_config = SimpleNamespace(is_gpu_index=False)
         milvus.client = FakeMilvusClient()
         monkeypatch.setattr("vectordb_bench.backend.clients.milvus.milvus.time.sleep", lambda _seconds: None)
@@ -197,6 +243,7 @@ class TestMilvusOptimize:
         milvus.collection_name = "test_collection"
         milvus._is_fts = False
         milvus._main_index_name = "vector_idx"
+        milvus.force_merge_target_size_mb = MILVUS_FORCE_MERGE_TARGET_SIZE_MB
         milvus.case_config = SimpleNamespace(is_gpu_index=False)
         milvus.client = FakeMilvusClient()
         monkeypatch.setattr("vectordb_bench.backend.clients.milvus.milvus.time.sleep", lambda _seconds: None)
@@ -247,6 +294,7 @@ class TestMilvusOptimize:
         milvus.name = "Milvus"
         milvus.collection_name = "test_collection"
         milvus._main_index_name = "vector_idx"
+        milvus.force_merge_target_size_mb = MILVUS_FORCE_MERGE_TARGET_SIZE_MB
         milvus.client = FakeMilvusClient()
         monkeypatch.setattr("vectordb_bench.backend.clients.milvus.milvus.time.sleep", lambda _seconds: None)
 
@@ -282,6 +330,37 @@ class TestMilvusOptimize:
 
         assert exc_info.value is error
         milvus.client.refresh_load.assert_not_called()
+
+
+class TestMilvusForceMergeTargetSize:
+    def test_resolve_defaults_to_unbounded_size(self):
+        assert MILVUS_FORCE_MERGE_TARGET_SIZE_MB == MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB
+        assert resolve_force_merge_target_size_mb({}) == MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB
+        assert resolve_force_merge_target_size_mb({"force_merge_target_size_mb": "2048"}) == 2048
+
+    @pytest.mark.parametrize("raw", [0, -1, "abc", 1.5])
+    def test_resolve_rejects_invalid_values(self, raw: object):
+        with pytest.raises(ValueError, match="force merge target size must be a positive whole number of MB"):
+            resolve_force_merge_target_size_mb({"force_merge_target_size_mb": raw})
+
+    def test_config_exposes_target_size(self):
+        uri = SecretStr("http://localhost:19530")
+        default_config = MilvusConfig(uri=uri)
+        assert default_config.to_dict()["force_merge_target_size_mb"] == MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB
+        assert MilvusConfig(uri=uri, force_merge_target_size_mb="512").to_dict()["force_merge_target_size_mb"] == 512
+        with pytest.raises(ValidationError):
+            MilvusConfig(uri=uri, force_merge_target_size_mb=0)
+
+    def test_init_reads_target_size_from_db_config(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("vectordb_bench.backend.clients.milvus.milvus.MilvusClient", MagicMock())
+
+        milvus = Milvus(
+            dim=8,
+            db_config={"uri": "http://localhost:19530", "force_merge_target_size_mb": 256},
+            db_case_config=AutoIndexConfig(),
+        )
+
+        assert milvus.force_merge_target_size_mb == 256
 
 
 @pytest.mark.integration

--- a/tests/test_milvus_zilliz_cli.py
+++ b/tests/test_milvus_zilliz_cli.py
@@ -2,6 +2,7 @@ from click.testing import CliRunner
 from pytest import MonkeyPatch
 
 from vectordb_bench.backend.clients.milvus import cli as milvus_cli
+from vectordb_bench.backend.clients.milvus.config import MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB
 from vectordb_bench.backend.clients.zilliz_cloud import cli as zilliz_cli
 
 
@@ -25,9 +26,28 @@ def test_milvus_cli_builds_shared_connection_config() -> None:
     assert config.num_shards == 2
     assert config.replica_number == 3
     assert config.collection_name == "bench_collection"
+    assert config.force_merge_target_size_mb == MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB
 
     parameters["password"] = None
     assert milvus_cli._build_milvus_config(parameters).password is None
+
+
+def test_milvus_cli_force_merge_target_size_option(monkeypatch: MonkeyPatch) -> None:
+    captured = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(milvus_cli, "run", fake_run)
+    base_args = ["--uri", "http://localhost:19530", "--dry-run"]
+
+    result = CliRunner().invoke(milvus_cli.MilvusAutoIndex, [*base_args, "--force-merge-target-size-mb", "1024"])
+    assert result.exit_code == 0, result.output
+    assert captured["db_config"].force_merge_target_size_mb == 1024
+
+    result = CliRunner().invoke(milvus_cli.MilvusAutoIndex, [*base_args, "--force-merge-target-size-mb", "0"])
+    assert result.exit_code != 0
+    assert "force-merge-target-size-mb" in result.output
 
 
 def test_milvus_autoindex_cli_enables_partition_key_for_multitenant_case(

--- a/vectordb_bench/backend/clients/milvus/cli.py
+++ b/vectordb_bench/backend/clients/milvus/cli.py
@@ -30,6 +30,11 @@ def _with_partition_key(db_case_config: BaseModel, parameters: dict) -> BaseMode
 def _build_milvus_config(parameters: dict) -> BaseModel:
     from .config import MilvusConfig
 
+    optional_params = {}
+    # omit the flag when unset so MilvusConfig keeps its own default (unbounded) target size
+    if parameters.get("force_merge_target_size_mb") is not None:
+        optional_params["force_merge_target_size_mb"] = int(parameters["force_merge_target_size_mb"])
+
     return MilvusConfig(
         db_label=parameters["db_label"],
         uri=SecretStr(parameters["uri"]),
@@ -38,6 +43,7 @@ def _build_milvus_config(parameters: dict) -> BaseModel:
         num_shards=int(parameters["num_shards"]),
         replica_number=int(parameters["replica_number"]),
         collection_name=parameters["collection_name"],
+        **optional_params,
     )
 
 
@@ -96,6 +102,19 @@ class MilvusTypedDict(TypedDict):
                 "Use the Milvus partition key on the label field. "
                 "Defaults to enabled for CloudMultiTenantSearchCase and disabled otherwise."
             ),
+        ),
+    ]
+    force_merge_target_size_mb: Annotated[
+        int | None,
+        click.option(
+            "--force-merge-target-size-mb",
+            type=click.IntRange(min=1),
+            help=(
+                "Target segment size in MB used by the force merge compaction before search. "
+                "Defaults to an unbounded size, merging each collection into a single segment."
+            ),
+            required=False,
+            default=None,
         ),
     ]
 

--- a/vectordb_bench/backend/clients/milvus/config.py
+++ b/vectordb_bench/backend/clients/milvus/config.py
@@ -1,8 +1,12 @@
 from typing import ClassVar
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, Field, SecretStr
 
 from ..api import DBCaseConfig, DBConfig, IndexType, MetricType, SQType
+
+# int64 max bytes expressed in MB, i.e. a practically unbounded target size that
+# lets force merge collapse all segments of a collection into a single one.
+MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB = ((1 << 63) - 1) // (1024**2)
 
 
 class MilvusConfig(DBConfig):
@@ -14,6 +18,7 @@ class MilvusConfig(DBConfig):
     num_shards: int = 1
     replica_number: int = 1
     collection_name: str = "VDBBench"
+    force_merge_target_size_mb: int = Field(default=MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB, gt=0)
 
     def to_dict(self) -> dict:
         return {
@@ -23,6 +28,7 @@ class MilvusConfig(DBConfig):
             "num_shards": self.num_shards,
             "replica_number": self.replica_number,
             "collection_name": self.collection_name,
+            "force_merge_target_size_mb": self.force_merge_target_size_mb,
         }
 
 

--- a/vectordb_bench/backend/clients/milvus/milvus.py
+++ b/vectordb_bench/backend/clients/milvus/milvus.py
@@ -12,13 +12,30 @@ from vectordb_bench.backend.filter import Filter, FilterOp
 from vectordb_bench.backend.payload import PayloadProfile
 
 from ..api import VectorDB
-from .config import MilvusFtsConfig, MilvusIndexConfig
+from .config import MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB, MilvusFtsConfig, MilvusIndexConfig
 
 log = logging.getLogger(__name__)
 
-MILVUS_FORCE_MERGE_TARGET_SIZE_MB = ((1 << 63) - 1) // (1024**2)
+MILVUS_FORCE_MERGE_TARGET_SIZE_MB = MILVUS_DEFAULT_FORCE_MERGE_TARGET_SIZE_MB
 MILVUS_FORCE_MERGE_MAX_ATTEMPTS = 10
 MILVUS_FORCE_MERGE_RETRY_INTERVAL_SECONDS = 30
+
+
+def resolve_force_merge_target_size_mb(db_config: dict | None) -> int:
+    """Resolve the force merge target size in MB, falling back to the unbounded default."""
+    raw = (db_config or {}).get("force_merge_target_size_mb")
+    if raw is None or raw == "":
+        return MILVUS_FORCE_MERGE_TARGET_SIZE_MB
+
+    message = f"force merge target size must be a positive whole number of MB, got {raw!r}"
+    try:
+        # str() first so fractional values are rejected instead of silently truncated
+        target_size_mb = int(str(raw))
+    except (TypeError, ValueError):
+        raise ValueError(message) from None
+    if target_size_mb <= 0:
+        raise ValueError(message)
+    return target_size_mb
 
 
 class Milvus(VectorDB):
@@ -52,6 +69,7 @@ class Milvus(VectorDB):
         self.case_config = db_case_config
         self.collection_name = collection_name
         self.with_scalar_labels = with_scalar_labels
+        self.force_merge_target_size_mb = resolve_force_merge_target_size_mb(db_config)
 
         self._scalar_label_field = "label"
         self._scalar_payload_label_field = self._scalar_label_field
@@ -326,10 +344,22 @@ class Milvus(VectorDB):
             message = "force merge max_attempts must be greater than zero"
             raise ValueError(message)
 
+        target_size_mb = self.force_merge_target_size_mb
+        # Only the unbounded default merges a collection into a single segment, so plan coverage
+        # can be verified. A smaller target size legitimately leaves segments that already reached
+        # it out of every plan, and there is nothing to retry, so run one compaction and stop.
+        if target_size_mb < MILVUS_FORCE_MERGE_TARGET_SIZE_MB:
+            log.info(f"{self.name} force merge with target size {target_size_mb} MB")
+            self._wait_for_compaction_ready()
+            compaction_id = self.client.compact(self.collection_name, target_size=target_size_mb)
+            if compaction_id > 0:
+                self._wait_for_compaction(compaction_id)
+            return
+
         for attempt in range(1, max_attempts + 1):
             self._wait_for_compaction_ready()
             expected_source_ids = self._force_merge_source_segment_ids()
-            compaction_id = self.client.compact(self.collection_name, target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
+            compaction_id = self.client.compact(self.collection_name, target_size=target_size_mb)
             if compaction_id <= 0:
                 failure_detail = f"generated no plan for snapshot {sorted(expected_source_ids)}"
             else:


### PR DESCRIPTION

I noticed that Milvus currently defaults to forcing merges into segments with a fixed size of int64 max value. In practice, this introduces uncertainty in segment sizing, particularly affected by DataNode memory usage.

```
MILVUS_FORCE_MERGE_TARGET_SIZE_MB = ((1 << 63) - 1) // (1024**2)
compaction_id = self.client.compact(self.collection_name, target_size=MILVUS_FORCE_MERGE_TARGET_SIZE_MB)
```

 I'd like to make this fixed value configurable via a parameter. The default behavior should remain unchanged (using the current maximum value), but when explicitly specified through configuration, the fixed segment size should become adjustable.

```
milvushnsw:
  case_type: Performance1536D50K
  uri: http://localhost:19530
  m: 16
  ef_construction: 128
  ef_search: 128
  force_merge_target_size_mb: 4096   
```