### PR TITLE
Fix: results sharing a task_label are dropped (show all, not just the first)

### DIFF
--- a/vectordb_bench/frontend/components/check_results/filters.py
+++ b/vectordb_bench/frontend/components/check_results/filters.py
@@ -50,10 +50,15 @@ def getshownResults(
         # label_visibility="hidden",
         default=default_selected_task_labels or resultSelectOptions,
     )
+    # Select every TestResult whose label is chosen, not just the first: more
+    # than one TestResult can share a task_label (e.g. the same engine re-run
+    # under one label), and index() would return only the first, silently
+    # dropping the rest from every results page.
+    selected = set(selectedResultSelectedOptions)
     selectedResult: list[CaseResult] = []
-    for option in selectedResultSelectedOptions:
-        case_results = results[resultSelectOptions.index(option)].results
-        selectedResult += [r for r in case_results if case_results_filter(r)]
+    for option, result in zip(resultSelectOptions, results):
+        if option in selected:
+            selectedResult += [r for r in result.results if case_results_filter(r)]
 
     return selectedResult
 


### PR DESCRIPTION
## Problem

`getshownResults` (`frontend/components/check_results/filters.py`) maps each selected task-label back to its results with `resultSelectOptions.index(option)`, which returns only the **first** TestResult carrying that label. When two or more TestResults share a `task_label`, every result after the first is **silently dropped** from all results pages (Results, Qps & Recall, Queries-Per-Dollar, Tables, …).

## Repro

1. Run any case with `--task-label demo` → `results/<DB>/result_<date>_demo_<db>.json`.
2. Run again (same or different config/db) with the **same** `--task-label demo` → a second result file / TestResult.
3. Open **Results** or **Qps & Recall** and select `demo`: only the first run is plotted; the second run's DB/points never appear, even though both files exist and load.

## Fix

Iterate every `(option, result)` pair and include each result whose label is selected, instead of `index()`-ing only the first match. No behavior change when task labels are unique.